### PR TITLE
Require String keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+
+## Design choices
+
+ * OnUpdate does not include message value because it could mean that consumers get old values, for example at retries or restarts.
+
+## Constraints
+
+ * Topic keys must be deserializable as [String](https://kafka.apache.org/21/javadoc/org/apache/kafka/common/serialization/Serdes.html#String--) because these strings are used in REST URIs.

--- a/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdate.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdate.java
@@ -8,11 +8,11 @@ public interface KeyvalueUpdate {
 
 	Topology getTopology();
 
-	byte[] getValue(byte[] key);
+	byte[] getValue(String key);
 
 	Long getCurrentOffset();
 
-	Iterator<byte[]> getKeys();
+	Iterator<String> getKeys();
 
   Iterator<byte[]> getValues();
 

--- a/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
@@ -2,7 +2,9 @@ package se.yolean.kafka.keyvalue;
 
 import java.util.Iterator;
 
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.processor.Processor;
@@ -62,7 +64,10 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
     Topology topology = new Topology();
 
 		topology
-		  .addSource(SOURCE_NAME, sourceTopicPattern)
+		  .addSource(SOURCE_NAME,
+		      new StringDeserializer(),
+		      new ByteArrayDeserializer(),
+		      sourceTopicPattern)
 		  .addProcessor(PROCESSOR_NAME, () -> this, SOURCE_NAME)
 		  .addStateStore(storeBuilder, PROCESSOR_NAME);
 

--- a/src/main/java/se/yolean/kafka/keyvalue/UpdateRecord.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/UpdateRecord.java
@@ -5,9 +5,9 @@ public class UpdateRecord {
   private String topic;
   private int partition;
   private long offset;
-  private byte[] key;
+  private String key;
 
-  public UpdateRecord(String topic, int partition, long offset, byte[] key) {
+  public UpdateRecord(String topic, int partition, long offset, String key) {
     this.topic = topic;
     this.partition = partition;
     this.offset = offset;
@@ -26,7 +26,7 @@ public class UpdateRecord {
     return offset;
   }
 
-  public byte[] getKey() {
+  public String getKey() {
     return key;
   }
 

--- a/src/test/java/se/yolean/kafka/keyvalue/KeyvalueUpdateIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/KeyvalueUpdateIntegrationTest.java
@@ -43,9 +43,9 @@ class KeyvalueUpdateIntegrationTest {
   void testBasicFlow() {
     testDriver.pipeInput(recordFactory.create(TOPIC1, "k1", "v1"));
 
-    assertEquals(null, cache.getValue("k0".getBytes()));
+    assertEquals(null, cache.getValue("k0"));
 
-    byte[] v1 = cache.getValue("k1".getBytes());
+    byte[] v1 = cache.getValue("k1");
     assertNotNull(v1);
     assertEquals("v1", new String(v1));
     assertEquals(1, onUpdate.getAll().size());
@@ -54,10 +54,10 @@ class KeyvalueUpdateIntegrationTest {
     assertEquals(TOPIC1, update1.getTopic());
     assertEquals(0, update1.getPartition());
     assertEquals(0, update1.getOffset());
-    assertEquals("k1", new String(update1.getKey()));
+    assertEquals("k1", update1.getKey());
 
     testDriver.pipeInput(recordFactory.create(TOPIC1, "k1", "v2"));
-    byte[] v2 = cache.getValue("k1".getBytes());
+    byte[] v2 = cache.getValue("k1");
     assertEquals("v2", new String(v2));
     assertEquals(2, onUpdate.getAll().size());
 
@@ -65,12 +65,12 @@ class KeyvalueUpdateIntegrationTest {
     assertEquals(TOPIC1, update2.getTopic());
     assertEquals(0, update2.getPartition());
     assertEquals(1, update2.getOffset());
-    assertEquals("k1", new String(update2.getKey()));
+    assertEquals("k1", update2.getKey());
     assertEquals(0, update1.getOffset());
 
-    Iterator<byte[]> keys = cache.getKeys();
+    Iterator<String> keys = cache.getKeys();
     assertTrue(keys.hasNext());
-    assertEquals("k1", new String(keys.next()));
+    assertEquals("k1", keys.next());
     assertFalse(keys.hasNext());
 
     Iterator<byte[]> values = cache.getValues();

--- a/src/test/java/se/yolean/kafka/keyvalue/OnUpdateRecordInMemoryTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/OnUpdateRecordInMemoryTest.java
@@ -14,7 +14,7 @@ class OnUpdateRecordInMemoryTest {
     OnUpdateRecordInMemory onUpdate = new OnUpdateRecordInMemory();
     assertEquals(onUpdate.getAll().size(), 0);
     final List<Object> ok = new LinkedList<Object>();
-    onUpdate.handle(new UpdateRecord("test", 0, 0, "0".getBytes()), new Runnable() {
+    onUpdate.handle(new UpdateRecord("test", 0, 0, "0"), new Runnable() {
       @Override
       public void run() {
         ok.add(null);


### PR DESCRIPTION
Realized that to have REST endpoints like `/messages/{key}` keys must be encoded as strings anyway, and it simplifies the code a bit to set that constraint.