### PR TITLE
Try to start up even if kafka and/or source topic is unavailable initially

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
-node_modules/
+*
+!src
+!build.gradle

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ The [build-contract](https://github.com/Yolean/build-contract/) can be used as d
 
 ```
 alias compose='docker-compose -f build-contracts/docker-compose.yml'
-compose up -d kafka
-compose up -d pixy
-compose up -d topic1-create
 compose up -d --build cache1
 compose up --build example-nodejs-client
 compose down

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -50,16 +50,12 @@ services:
 
   topic1-create:
     image: solsson/kafkacat@sha256:b91241b5741fccaef282eb8dbdfb6e5289bb8586274175b1836e57912ffecaef
+    entrypoint:
+    - /bin/bash
+    - -c
     command:
-    - -b
-    -  kafka:9092
-    # good enough with auto topic create
-    - -C
-    - -K
-    -  '='
-    - -t
-    -  topic1
-    - -e
+    - |
+      until kafkacat -b kafka:9092 -C -K '=' -t topic1 -e; do sleep 3; done
 
   cache1:
     depends_on:
@@ -84,6 +80,8 @@ services:
     -   kv-001
     - --topic
     -   topic1
+    - --starttimeout
+    -   '10'
 
   example-nodejs-client:
     depends_on:

--- a/src/main/java/se/yolean/kafka/keyvalue/App.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/App.java
@@ -1,23 +1,60 @@
 package se.yolean.kafka.keyvalue;
 
+import java.util.Collection;
+
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.state.StreamsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import se.yolean.kafka.keyvalue.healthz.StreamsStateListener;
+import se.yolean.kafka.keyvalue.healthz.StreamsUncaughtExceptionHandler;
 import se.yolean.kafka.keyvalue.http.CacheServer;
 import se.yolean.kafka.keyvalue.http.ConfigureRest;
 import se.yolean.kafka.keyvalue.http.ReadinessServlet;
+import se.yolean.kafka.keyvalue.metrics.StreamsMetrics;
 
 public class App {
 
+  private static final Logger logger = LoggerFactory.getLogger(App.class);
+
+  private long streamsStatusCheckInterval = 5000;
+  private int checksBeforeRequireRunning = 3;
+
+  private final StreamsStateListener stateListener = new StreamsStateListener();
+  private final StreamsUncaughtExceptionHandler streamsExceptionHandler = new StreamsUncaughtExceptionHandler();
+  private long streamsStartTime = -1;
+  private StreamsMetrics metrics = null;
+
   public App(CacheServiceOptions options) {
+    logger.info("Starting App using options {}", options);
+
     KeyvalueUpdate keyvalueUpdate = new KeyvalueUpdateProcessor(
         options.getTopicName(),
         options.getOnUpdate());
+    logger.info("Processor created");
+
     Topology topology = keyvalueUpdate.getTopology();
+    logger.info("Topology created, starting Streams using {} custom props",
+        options.getStreamsProperties().size());
 
     KafkaStreams streams = new KafkaStreams(topology, options.getStreamsProperties());
+    logger.info("Streams application configured", streams);
+
+    streams.setStateListener(stateListener);
+    logger.info("Registered streams state listener {}", stateListener);
+
+    streams.setUncaughtExceptionHandler(streamsExceptionHandler);
+    logger.info("Registered streams exception handler {}", streamsExceptionHandler);
+
+    metrics = new StreamsMetrics(streams.metrics());
+    logger.info("Will follow metrics through {}", metrics);
 
     Endpoints endpoints = new Endpoints(keyvalueUpdate);
+    logger.info("Starting REST service with endpoints {}", endpoints);
+
     CacheServer server = new ConfigureRest()
         .createContext(options.getPort(), "/")
         .registerResourceClass(org.glassfish.jersey.jackson.JacksonFeature.class)
@@ -26,16 +63,68 @@ public class App {
         // TODO metrics: .addCustomServlet(servlet, pathSpec)
         .addCustomServlet(new ReadinessServlet(keyvalueUpdate), "/ready")
         .create();
+    logger.info("REST server created {}", server);
+
     server.start();
+    logger.info("REST server stated");
 
     Runtime.getRuntime().addShutdownHook(new Thread(() -> streams.close()));
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
         try {
             server.stop();
         } catch (Exception e) {}
+        logger.info("REST server stopped");
     }));
 
+    runStreams(streams);
+  }
+
+  private void runStreams(KafkaStreams streams) {
+    startStreams(streams);
+
+    while (true) {
+      try {
+        Thread.sleep(streamsStatusCheckInterval);
+      } catch (InterruptedException e) {
+        logger.error("Interrupted after streams start", e);
+      }
+      watchStreams(streams);
+    }
+  }
+
+  private void watchStreams(KafkaStreams streams) {
+    metrics.check();
+    if (checksBeforeRequireRunning > 0) {
+      logger.info("Looking for signs of successful startup");
+      if (metrics.hasSeenAssignedParititions() && stateListener.streamsHasBeenRunning()) {
+        checksBeforeRequireRunning = -1;
+      } else {
+        checksBeforeRequireRunning--;
+      }
+    }
+    if (checksBeforeRequireRunning == 0) {
+      logger.error("Failed to confirm streams startup in {} secods", (System.currentTimeMillis() - streamsStartTime) / 1000);
+      checksBeforeRequireRunning = 3;
+      restartStreams(streams);
+    }
+  }
+
+  private void startStreams(KafkaStreams streams) {
+    streamsStartTime = System.currentTimeMillis();
+    logger.info("Starting streams application at {}", streamsStartTime);
     streams.start();
+    logger.info("Streams application started");
+  }
+
+  private void restartStreams(KafkaStreams streams) {
+    logger.warn("Forcing streams instance restart");
+    streams.close();
+    try {
+      Thread.sleep(streamsStatusCheckInterval);
+    } catch (InterruptedException e) {
+      logger.error("Interrupted after streams close", e);
+    }
+    startStreams(streams);
   }
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/CacheServiceOptions.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/CacheServiceOptions.java
@@ -2,6 +2,11 @@ package se.yolean.kafka.keyvalue;
 
 import java.util.Properties;
 
+import se.yolean.kafka.keyvalue.cli.ArgsToOptions;
+
+/**
+ * See CLI help in {@link ArgsToOptions} for documentation.
+ */
 public interface CacheServiceOptions {
 
   String getApplicationId();
@@ -13,5 +18,7 @@ public interface CacheServiceOptions {
   Properties getStreamsProperties();
 
   OnUpdate getOnUpdate();
+
+  Integer getStartTimeoutSecods();
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
@@ -29,7 +29,7 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
 
 	private String sourceTopicPattern;
   private OnUpdate onUpdate;
-  private ProcessorContext context;
+  private ProcessorContext context = null;
 
   // We can't use this to build so we keep it for sanity checks
   private StoreBuilder<KeyValueStore<String, byte[]>> storeBuilder = null;
@@ -94,6 +94,9 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
   }
 
   public boolean isReady() {
+    if (context == null) {
+      return false;
+    }
     throw new UnsupportedOperationException("TODO remains to figure out how to know if the cache is warmed up");
   }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/cli/ArgsToOptions.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/cli/ArgsToOptions.java
@@ -54,7 +54,8 @@ public class ArgsToOptions implements CacheServiceOptions {
         .type(String.class)
         .dest("streamsConfig")
         .help("kafka streams related configuration properties like bootstrap.servers etc. " +
-                "These configs take precedence over those passed via --streams.config.");
+                "These configs take precedence over those passed via --streams.config." +
+                "The consumer can be configured using prefix: " + StreamsConfig.CONSUMER_PREFIX + ".");
 
     parser.addArgument("--streams.config")
         .action(store())

--- a/src/main/java/se/yolean/kafka/keyvalue/cli/ArgsToOptions.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/cli/ArgsToOptions.java
@@ -28,6 +28,7 @@ public class ArgsToOptions implements CacheServiceOptions {
   private String applicationId;
   private Properties streamsProperties = null;
   private OnUpdate onUpdate = null;
+  private Integer startTimeoutSeconds = null;
 
   public ArgsToOptions setOnUpdateFactory(OnUpdateFactory factory) {
     this.onUpdateFactory  = factory;
@@ -54,7 +55,7 @@ public class ArgsToOptions implements CacheServiceOptions {
         .type(String.class)
         .dest("streamsConfig")
         .help("kafka streams related configuration properties like bootstrap.servers etc. " +
-                "These configs take precedence over those passed via --streams.config." +
+                "These configs take precedence over those passed via --streams.config. " +
                 "The consumer can be configured using prefix: " + StreamsConfig.CONSUMER_PREFIX + ".");
 
     parser.addArgument("--streams.config")
@@ -97,6 +98,16 @@ public class ArgsToOptions implements CacheServiceOptions {
         .metavar("ONUPDATE")
         .help("A URL to POST the key to upon updates (may be debounced)");
 
+    parser.addArgument("--starttimeout")
+        .action(store())
+        .required(false)
+        .type(Integer.class)
+        .metavar("STARTTIMEOUT")
+        .setDefault(0)
+        .help("Activates retries: close+restart of the streams setup if it fails to go online."
+            + " Useful because Streams' kafka client has retries but failure conditions like missing source topic don't."
+            + " Set to >0 to enable a check after this many seconds.");
+
     return parser;
   }
 
@@ -119,6 +130,7 @@ public class ArgsToOptions implements CacheServiceOptions {
       List<String> streamsProps = res.getList("streamsConfig");
       String streamsConfig = res.getString("streamsConfigFile");
       onupdateUrl = res.getString("onupdate");
+      startTimeoutSeconds = res.getInt("starttimeout");
 
       if (streamsProps == null && streamsConfig == null) {
         throw new ArgumentParserException("Either --streams-props or --streams.config must be specified.", parser);
@@ -140,7 +152,9 @@ public class ArgsToOptions implements CacheServiceOptions {
       }
 
       props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
-      // props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, hostName + ":" + port);
+      // For when we start to deal with metadata and replicas like in https://medium.com/bakdata/queryable-kafka-topics-with-kafka-streams-8d2cca9de33f
+      //props.put(StreamsConfig.APPLICATION_SERVER_CONFIG, hostName + ":" + port);
+
     } catch (ArgumentParserException e) {
       if (args.length == 0) {
         parser.printHelp();
@@ -165,44 +179,34 @@ public class ArgsToOptions implements CacheServiceOptions {
     return this;
   }
 
-  /* (non-Javadoc)
-   * @see se.yolean.kafka.keyvalue.CacheServiceOptions#getTopicName()
-   */
   @Override
   public String getTopicName() {
     return topicName;
   }
 
-  /* (non-Javadoc)
-   * @see se.yolean.kafka.keyvalue.CacheServiceOptions#getPort()
-   */
   @Override
   public Integer getPort() {
     return port;
   }
 
-  /* (non-Javadoc)
-   * @see se.yolean.kafka.keyvalue.CacheServiceOptions#getStreamsProperties()
-   */
   @Override
   public Properties getStreamsProperties() {
     return streamsProperties;
   }
 
-  /* (non-Javadoc)
-   * @see se.yolean.kafka.keyvalue.CacheServiceOptions#getOnUpdate()
-   */
   @Override
   public OnUpdate getOnUpdate() {
     return onUpdate;
   }
 
-  /* (non-Javadoc)
-   * @see se.yolean.kafka.keyvalue.CacheServiceOptions#getApplicationId()
-   */
   @Override
   public String getApplicationId() {
     return applicationId;
+  }
+
+  @Override
+  public Integer getStartTimeoutSecods() {
+    return startTimeoutSeconds;
   }
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/cli/Main.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/cli/Main.java
@@ -1,10 +1,17 @@
 package se.yolean.kafka.keyvalue.cli;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.yolean.kafka.keyvalue.App;
 import se.yolean.kafka.keyvalue.CacheServiceOptions;
 import se.yolean.kafka.keyvalue.onupdate.OnUpdateFactory;
 
 public class Main {
+
+  private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+  private static long maintenanceCallInterval = 5000;
 
   public static void main(String[] args) {
     OnUpdateFactory onUpdateFactory = OnUpdateFactory.getInstance();
@@ -13,7 +20,32 @@ public class Main {
         .setOnUpdateFactory(onUpdateFactory)
         .fromCommandLineArguments(args);
 
-    new App(options);
+    long appStartTime = -1;
+    App app = null;
+
+    while (true) {
+      if (app == null) {
+        appStartTime  = System.currentTimeMillis();
+        logger.info("Initializing streams app");
+        app = new App(options);
+      }
+
+      try {
+        Thread.sleep(maintenanceCallInterval);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+
+      app.doWhateverRegularMaintenance();
+
+      if (!app.hasConnectedToSourceTopic()
+          && options.getStartTimeoutSecods() > 0
+          && System.currentTimeMillis() - appStartTime > options.getStartTimeoutSecods() * 1000) {
+        logger.error("No sign of success for app start. Shutting down to retry.");
+        app.shutdown();
+        app = null;
+      }
+    }
   }
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/healthz/StreamsStateListener.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/healthz/StreamsStateListener.java
@@ -1,0 +1,32 @@
+package se.yolean.kafka.keyvalue.healthz;
+
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Needed because transitions say more than calls to streams.state()
+ */
+public class StreamsStateListener implements StateListener {
+
+  public final Logger logger = LoggerFactory.getLogger(StreamsStateListener.class);
+
+  private boolean hasBeenRunning = false;
+
+  /**
+   * @return true if streams seems to have been running at any time
+   */
+  public boolean streamsHasBeenRunning() {
+    return hasBeenRunning;
+  }
+
+  @Override
+  public void onChange(State newState, State oldState) {
+    logger.info("Streams state change to {} from {}", newState, oldState);
+    if (State.RUNNING.equals(newState) && State.REBALANCING.equals(oldState)) {
+      hasBeenRunning = true;
+    }
+  }
+
+}

--- a/src/main/java/se/yolean/kafka/keyvalue/healthz/StreamsStateListener.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/healthz/StreamsStateListener.java
@@ -23,7 +23,7 @@ public class StreamsStateListener implements StateListener {
 
   @Override
   public void onChange(State newState, State oldState) {
-    logger.info("Streams state change to {} from {}", newState, oldState);
+    logger.info("Streams state change from {} to {}", oldState, newState);
     if (State.RUNNING.equals(newState) && State.REBALANCING.equals(oldState)) {
       hasBeenRunning = true;
     }

--- a/src/main/java/se/yolean/kafka/keyvalue/healthz/StreamsUncaughtExceptionHandler.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/healthz/StreamsUncaughtExceptionHandler.java
@@ -1,0 +1,17 @@
+package se.yolean.kafka.keyvalue.healthz;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StreamsUncaughtExceptionHandler implements UncaughtExceptionHandler {
+
+  private final Logger logger = LoggerFactory.getLogger(StreamsUncaughtExceptionHandler.class);
+
+  @Override
+  public void uncaughtException(Thread t, Throwable e) {
+    logger.error("Got uncaught streams exception in thread {}", t, e);
+  }
+
+}

--- a/src/main/java/se/yolean/kafka/keyvalue/metrics/KafkaMetricToPrometheus.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/metrics/KafkaMetricToPrometheus.java
@@ -1,0 +1,37 @@
+package se.yolean.kafka.keyvalue.metrics;
+
+import org.apache.kafka.common.MetricName;
+
+/**
+ * WIP matching and/or mapping to exported metrics.
+ */
+public class KafkaMetricToPrometheus {
+
+  private String kafkaName;
+  private String kafkaGroup;
+
+  public KafkaMetricToPrometheus(String kafkaGroup, String kafkaName) {
+    if (kafkaName == null) {
+      throw new IllegalArgumentException("Metric name can not be null");
+    }
+    if (kafkaGroup == null) {
+      throw new IllegalArgumentException("Metric group can not be null");
+    }
+    this.kafkaName = kafkaName;
+    this.kafkaGroup = kafkaGroup;
+  }
+
+  /**
+   * Note: can not be used to .get from the metrics map, because equals here is never called.
+   */
+  @Override
+  public boolean equals(Object other) {
+    if (other == null) return false;
+    if (MetricName.class.isInstance(other)) {
+      MetricName metricName = (MetricName) other;
+      return kafkaGroup.equals(metricName.group()) && kafkaName.equals(metricName.name());
+    }
+    return false;
+  }
+
+}

--- a/src/main/java/se/yolean/kafka/keyvalue/metrics/StreamsMetrics.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/metrics/StreamsMetrics.java
@@ -44,7 +44,7 @@ public class StreamsMetrics {
         Double partitions = (Double) metricValue;
         if (partitions > 0.5) {
           hasSeenAssignedParititions = true;
-          logger.info("Saw assigned partitions for the first time");
+          logger.info("Noticed assigned partitions for the first time");
         }
       }
       String name = metric.name();

--- a/src/main/java/se/yolean/kafka/keyvalue/metrics/StreamsMetrics.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/metrics/StreamsMetrics.java
@@ -1,0 +1,66 @@
+package se.yolean.kafka.keyvalue.metrics;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StreamsMetrics {
+
+  public static final Logger logger = LoggerFactory.getLogger(StreamsMetrics.class);
+
+  private static final KafkaMetricToPrometheus ASSIGNED_PARTITIONS =
+      new KafkaMetricToPrometheus("consumer-coordinator-metrics", "assigned-partitions");
+
+  // These might be interesting too for health
+  private static final KafkaMetricToPrometheus COMMIT_TOTAL =
+      new KafkaMetricToPrometheus("consumer-coordinator-metrics", "commit-total");
+  private static final KafkaMetricToPrometheus RECORDS_CONSUMED_TOTAL =
+      new KafkaMetricToPrometheus("consumer-fetch-manager-metrics", "records-consumed-total");
+
+  private Map<MetricName, ? extends Metric> metrics;
+
+  private boolean hasSeenAssignedParititions = false;
+
+  /**
+   * @param metrics The handle to global state from KafkaStreams
+   */
+  public StreamsMetrics(Map<MetricName, ? extends Metric> metrics) {
+    this.metrics = metrics;
+  }
+
+  /**
+   * So we can trigger re-check frorm the main thread without being clever here, yet.
+   * Possibly obsolete when we integrate with prometheus.
+   */
+  public void check() {
+    for (MetricName metric : metrics.keySet()) {
+      Object metricValue = metrics.get(metric).metricValue();
+      if (!hasSeenAssignedParititions && ASSIGNED_PARTITIONS.equals(metric)) {
+        Double partitions = (Double) metricValue;
+        if (partitions > 0.5) {
+          hasSeenAssignedParititions = true;
+          logger.info("Saw assigned partitions for the first time");
+        }
+      }
+      String name = metric.name();
+      String group = metric.group();
+      if (name.contains("-rate")) {
+        logger.trace("{}:{}={} #{}", group, name, metricValue, metric.description());
+      } else if (group.startsWith("admin-client-")) {
+        logger.trace("{}:{}={} #{}", group, name, metricValue, metric.description());
+      } else {
+        logger.debug("{}:{}={} #{}", group, name, metricValue, metric.description());
+      }
+    }
+  }
+
+  public boolean hasSeenAssignedParititions() {
+    return hasSeenAssignedParititions;
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java
@@ -14,12 +14,13 @@ class ArgsToOptionsTest {
 
   @Test
   void test() {
-    String args = "--port 19081 "
-        + "--streams-props bootstrap.servers=localhost:19092 num.standby.replicas=0 "
-        + "--hostname mypod-abcde "
-        + "--topic topic1 "
-        + "--application-id kv-test1-001 "
-        + "--onupdate http://127.0.0.1:8081/updated";
+    String args = "--port 19081"
+        + " --streams-props bootstrap.servers=localhost:19092 num.standby.replicas=0"
+        + " --hostname mypod-abcde"
+        + " --topic topic1"
+        + " --application-id kv-test1-001"
+        + " --onupdate http://127.0.0.1:8081/updated"
+        + " --starttimeout 15";
     OnUpdateFactory onUpdateFactory = Mockito.mock(OnUpdateFactory.class);
     ArgsToOptions a = new ArgsToOptions();
     a.setOnUpdateFactory(onUpdateFactory);
@@ -31,6 +32,7 @@ class ArgsToOptionsTest {
     Properties props = options.getStreamsProperties();
     assertEquals("localhost:19092", props.get("bootstrap.servers"));
     assertEquals("0", props.get("num.standby.replicas"));
+    assertEquals(15, options.getStartTimeoutSecods());
   }
 
 }

--- a/src/test/java/se/yolean/kafka/keyvalue/healthz/StreamsStateListenerTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/healthz/StreamsStateListenerTest.java
@@ -1,0 +1,38 @@
+package se.yolean.kafka.keyvalue.healthz;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.junit.jupiter.api.Test;
+
+class StreamsStateListenerTest {
+
+  /**
+   * Based on observations using logging with Streams 2.1.0
+   */
+  @Test
+  void testStatesAtStartupWithNonexistentTopic() {
+    StreamsStateListener listener = new StreamsStateListener();
+    // happens right after start
+    listener.onChange(State.RUNNING, State.CREATED);
+    listener.onChange(State.REBALANCING, State.RUNNING);
+    // what sucks is that we never get these state transitions
+    // INFO org.apache.kafka.streams.processor.internals.StreamThread - stream-thread [-StreamThread-1] State transition from PARTITIONS_REVOKED to PENDING_SHUTDOWN
+    // INFO org.apache.kafka.streams.processor.internals.StreamThread - stream-thread [-StreamThread-1] State transition from PENDING_SHUTDOWN to DEAD
+    // and .state() makes no difference, it also reports REBALANCING
+    assertFalse(listener.streamsHasBeenRunning());
+  }
+
+  /**
+   * Based on observations using logging with Streams 2.1.0
+   */
+  @Test
+  void testStatesAtStartupWithTopic() {
+    StreamsStateListener listener = new StreamsStateListener();
+    listener.onChange(State.RUNNING, State.CREATED);
+    listener.onChange(State.REBALANCING, State.RUNNING);
+    listener.onChange(State.RUNNING, State.REBALANCING);
+    assertTrue(listener.streamsHasBeenRunning());
+  }
+
+}


### PR DESCRIPTION
This turned out to be an exercise in monitoring streams applications from within.

The problem, that causes lots of issues during development, is that streams:

- Properly retries when kafka is unavailable
- Stops unrecoverably when kafka went online but the source topic is missing.
- Doesn't report this shutdown through for example the StatusListener
- Doesn't throw any exception