### PR TITLE
Add shell script and docker image for build

### DIFF
--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -3,9 +3,9 @@ set -e
 # TODO make jib build run the unit tests
 # If all tooling is available locally use
 #gradlejibdocker=gradle
-gradlejibdocker="docker run --rm -v $(pwd):/workspace -v /var/run/docker.sock:/var/run/docker.sock solsson/gradle-jib-docker:latest gradle"
-$gradlejibdocker --no-daemon --no-parallel --no-build-cache --stacktrace test
-$gradlejibdocker --no-daemon --no-parallel --no-build-cache --stacktrace jibDockerBuild --image=yolean/kafka-keyvalue:dev
+gradlejibdocker="docker run --rm -v $(pwd):/workspace -v /var/run/docker.sock:/var/run/docker.sock solsson/gradle-jib-docker:latest gradle --no-daemon --no-parallel --no-build-cache"
+$gradlejibdocker --stacktrace test
+$gradlejibdocker --stacktrace jibDockerBuild --image=yolean/kafka-keyvalue:dev
 build-contract
 docker tag yolean/kafka-keyvalue:dev yolean/kafka-keyvalue:latest
 docker push yolean/kafka-keyvalue:latest

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 set -e
 # TODO make jib build run the unit tests
-# TODO invent a docker image with the tooling below, to make builds reproducible
-gradle test
-gradle jibDockerBuild --image=yolean/kafka-keyvalue:dev
+# If all tooling is available locally use
+#gradlejibdocker=gradle
+gradlejibdocker="docker run --rm -v $(pwd):/workspace -v /var/run/docker.sock:/var/run/docker.sock solsson/gradle-jib-docker:latest gradle"
+$gradlejibdocker --no-daemon --no-parallel --no-build-cache --stacktrace test
+$gradlejibdocker --no-daemon --no-parallel --no-build-cache --stacktrace jibDockerBuild --image=yolean/kafka-keyvalue:dev
 build-contract
 docker tag yolean/kafka-keyvalue:dev yolean/kafka-keyvalue:latest
 docker push yolean/kafka-keyvalue:latest

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,5 +1,8 @@
-FROM solsson/jdk-opensource:11.0.1@sha256:740feb6c1ecbdf2beac1dc41405c3215511b90d83a7211f805e88f92946dd2a9
+FROM gradle:5.2.1-jdk11-slim@sha256:d76c7448ee9923493a9155c771a904ff6cedc3e3f4813416402debd125d21a48
 
+USER root
+
+# Installs docker like we do in https://github.com/Yolean/kafka-cache/
 ENV docker_version=17.09.1~ce-0~debian
 
 RUN export DEBIAN_FRONTEND=noninteractive \
@@ -15,10 +18,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # This image expects a mounted docker.sock or env that points to docker tcp
 RUN update-rc.d -f docker remove
 
-ENV GRADLE_VERSION=5.2.1
+USER gradle
+# actually no, non-root typically won't be allowed to push to docker
+# This might however mess up file rights in .gradle
+USER root
 
-RUN cd /opt \
-  && curl -o gradle-${GRADLE_VERSION}.zip -sLS https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
-  && unzip gradle-${GRADLE_VERSION}.zip \
-  && rm gradle-${GRADLE_VERSION}.zip \
-  && ln -s /opt/gradle-5.2.1/bin/gradle /usr/local/bin/gradle
+WORKDIR /workspace

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,24 @@
+FROM solsson/jdk-opensource:11.0.1@sha256:740feb6c1ecbdf2beac1dc41405c3215511b90d83a7211f805e88f92946dd2a9
+
+ENV docker_version=17.09.1~ce-0~debian
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get install -y apt-transport-https curl ca-certificates gnupg2 unzip \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+  && apt-key fingerprint 0EBFCD88 \
+  && echo "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends docker-ce=$docker_version \
+  && rm -r /var/lib/apt/lists/*
+
+# This image expects a mounted docker.sock or env that points to docker tcp
+RUN update-rc.d -f docker remove
+
+ENV GRADLE_VERSION=5.2.1
+
+RUN cd /opt \
+  && curl -o gradle-${GRADLE_VERSION}.zip -sLS https://downloads.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  && unzip gradle-${GRADLE_VERSION}.zip \
+  && rm gradle-${GRADLE_VERSION}.zip \
+  && ln -s /opt/gradle-5.2.1/bin/gradle /usr/local/bin/gradle


### PR DESCRIPTION
Could be simplified if we push directly to a registry in the first step. Could run in kubernetes then too (assuming kompose could be used with build-contract) because we wouldn't need docker daemon access.

I have a docker hub automated build for the runner image.