### PR TITLE
Make all tests wait for services to come online

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceCompatibility = 1.11
 
 jib {
   from {
-    image = 'gcr.io/distroless/java@sha256:8ba52a2d23b816325c7c95c486f4e41b9fe1ae52ed6c270073328aabc80e6df7'
+    image = 'gcr.io/distroless/java@sha256:e864e875b685ef5695b406a40225ae2d881badf6b0f623e4f3ae9824b65602b4'
   }
   to {
     image = 'yolean/kafka-keyvalue'

--- a/example-nodejs-client/cache-update-flow.spec.js
+++ b/example-nodejs-client/cache-update-flow.spec.js
@@ -9,12 +9,11 @@ const {
 const fetch = require('node-fetch');
 const { gzipSync, gunzipSync } = require('zlib');
 
+// we don't use mockserver for any asserts now (onupdate- spec does that) but the access logging is a bit useful for multi-onupdate still
 const mockserver = require('./mockserver');
-
 beforeAll(() => {
   mockserver.start();
 });
-
 afterAll(() => {
   mockserver.stop();
 });

--- a/example-nodejs-client/cache-update-flow.spec.js
+++ b/example-nodejs-client/cache-update-flow.spec.js
@@ -9,25 +9,6 @@ const {
 const fetch = require('node-fetch');
 const { gzipSync, gunzipSync } = require('zlib');
 
-// retry on no connection, but not on any status code
-// There's node-fetch-retry and node-fetch-plus if we want libs
-const fetchRetry = async (url, opts) => {
-  let retry = opts && opts.retries || 3
-  while (retry > 0) {
-    try {
-      return await fetch(url, opts)
-    } catch(e) {
-      if (opts.retryCallback) {
-          opts.retryCallback(retry)
-      }
-      retry = retry - 1
-      if (retry == 0) {
-          throw e
-      }
-    }
-  }
-};
-
 const mockserver = require('./mockserver');
 
 beforeAll(() => {
@@ -43,53 +24,6 @@ describe("A complete cache update flow", () => {
   test("Check that the mock server is online on port " + mockserver.port, async () => {
     const response = await fetch(mockserver.localroot);
     expect(response.status).toEqual(200);
-  });
-
-  test("Check that pixy is online at " + PIXY_HOST, async () => {
-    let response = await fetchRetry(PIXY_HOST, {
-      timeout: 3,
-      retries: 5,
-      retryCallback: retry => console.log('Retrying pixy access', retry)
-    });
-    expect(response.status).toEqual(404);
-  });
-
-  test("Check existence of test topic " + TOPIC1_NAME, async () => {
-    let retries = 5;
-    while (retries > 0) {
-      try {
-        const response = await fetch(`${PIXY_HOST}/topics`, {
-          timeout: 3,
-          method: 'GET',
-          headers: {
-            'Accept': 'application/json'
-          }
-        });
-        expect(response.status).toEqual(200);
-        expect(await response.json()).toContain(TOPIC1_NAME);
-        retries = 0;
-      } catch (e) {
-        if (retries-- < 1) throw e;
-        console.log('Retrying topic existence', retries);
-      }
-    }
-  });
-
-  test("Check that cache is online at " + CACHE1_HOST, async () => {
-    //const response = await fetch(`${CACHE1_HOST}/ready`, {
-    const response = await fetchRetry(`${CACHE1_HOST}/`, {
-      method: 'GET',
-      headers: {
-        'Accept': 'application/json'
-      },
-      timeout: 3,
-      retries: 10,
-      retryCallback: retry => console.log('Retrying cache access', retry)
-    });
-    //expect(response.status).toEqual(204);
-    // For now we don't have a working readiness check
-    //expect(response.status).toEqual(500);
-    expect(response.status).toEqual(404);
   });
 
   it("Starts with a produce to Pixy", async () => {

--- a/example-nodejs-client/jest.config.js
+++ b/example-nodejs-client/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  globalSetup: './stack-setup'
+}

--- a/example-nodejs-client/package-lock.json
+++ b/example-nodejs-client/package-lock.json
@@ -4314,6 +4314,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retryx": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/retryx/-/retryx-0.0.7.tgz",
+      "integrity": "sha512-h+Wnuc+7eaha/mC4O+sFThsLdnqBXwrvSoDQhmlZ6PI7sS1LKMY+nGBkISA0QIeDV+mGpTt4sAPqe9QwNr4fuw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",

--- a/example-nodejs-client/package.json
+++ b/example-nodejs-client/package.json
@@ -15,6 +15,7 @@
     "mockserver-node": "5.5.2",
     "morgan": "1.9.1",
     "node-fetch": "2.3.0",
+    "retryx": "0.0.7",
     "sinon": "7.2.3"
   }
 }

--- a/example-nodejs-client/stack-setup.js
+++ b/example-nodejs-client/stack-setup.js
@@ -34,21 +34,18 @@ module.exports = async function() {
   if (cache.status !== 404) console.warn('Unexpected cache service response status', cache.status, PIXY_HOST);
   console.log('Cache service is reachable at', CACHE1_HOST);
 
-  const topic = await retryx(() => new Promise((resolve, reject) => {
-    return fetch(`${PIXY_HOST}/topics`, {
+  const topic = await retryx(() => fetch(`${PIXY_HOST}/topics`, {
       method: 'GET',
       headers: {
         'Accept': 'application/json'
       }
-    }).then(response => {
-      return response.json().then(topics => {
-        if (!topics || !topics.length) return reject('Unexpected topics response ' + topics);
-        if (topics.indexOf(TOPIC1_NAME) === -1) return reject('Topic ' + TOPIC1_NAME + ' not found in: ' + topics);
+    }).then(response => response.json().then(topics => {
+        if (!topics || !topics.length) return Promise.reject('Unexpected topics response ' + topics);
+        if (topics.indexOf(TOPIC1_NAME) === -1) return Promise.reject('Topic ' + TOPIC1_NAME + ' not found in: ' + topics);
         console.log('Found test topic ' + TOPIC1_NAME + ' in pixy\'s topic list');
-        resolve(response);
-      });
-    });
-  }),{
+        Promise.resolve(response);
+    }))
+  ,{
     maxTries: 10,
     beforeWait: n => console.log('Try', n, 'topic existence', TOPIC1_NAME)
   });

--- a/example-nodejs-client/stack-setup.js
+++ b/example-nodejs-client/stack-setup.js
@@ -1,4 +1,5 @@
-// wait for services in ../build-contracts
+// Doens't actually set up anything
+// Waits for services in ../build-contracts
 
 const {
   PIXY_HOST = 'http://localhost:19090',
@@ -8,36 +9,48 @@ const {
 } = process.env;
 
 const fetch = require('node-fetch');
-
-// retry on no connection, but not on any status code
-// There's node-fetch-retry and node-fetch-plus if we want libs
-const fetchRetry = async (url, opts) => {
-  let retry = opts && opts.retries || 3
-  while (retry > 0) {
-    try {
-      return await fetch(url, opts)
-    } catch(e) {
-      if (opts.retryCallback) {
-          opts.retryCallback(retry)
-      }
-      retry = retry - 1
-      if (retry == 0) {
-          throw e
-      }
-    }
-  }
-};
+const retryx = require('retryx');
 
 module.exports = async function() {
   console.log(' Looking for test stack...');
 
-  //test("Check that pixy is online at " + PIXY_HOST, async () => {
-  let response = await fetchRetry(PIXY_HOST, {
-    timeout: 3,
-    retries: 10,
-    retryCallback: retry => console.log(new Date(), 'Retrying pixy access', retry)
+  let pixy = await retryx(() => fetch(PIXY_HOST, {
+  }),{
+    maxTries: 10,
+    beforeWait: n => console.log('Try', n, 'pixy access at', PIXY_HOST)
   });
-  //expect(response.status).toEqual(404);
-  //});
+  if (pixy.status !== 404) console.warn('Unexpected pixy response status', pixy.status, PIXY_HOST);
+  console.log('Pixy is reachable at', PIXY_HOST);
+
+  const cache = await retryx(() => fetch(`${CACHE1_HOST}/`, {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json'
+    }
+  }),{
+    maxTries: 10,
+    beforeWait: n => console.log('Try', n, 'cache access at', CACHE1_HOST)
+  });
+  if (cache.status !== 404) console.warn('Unexpected cache service response status', cache.status, PIXY_HOST);
+  console.log('Cache service is reachable at', CACHE1_HOST);
+
+  const topic = await retryx(() => new Promise((resolve, reject) => {
+    return fetch(`${PIXY_HOST}/topics`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json'
+      }
+    }).then(response => {
+      return response.json().then(topics => {
+        if (!topics || !topics.length) return reject('Unexpected topics response ' + topics);
+        if (topics.indexOf(TOPIC1_NAME) === -1) return reject('Topic ' + TOPIC1_NAME + ' not found in: ' + topics);
+        console.log('Found test topic ' + TOPIC1_NAME + ' in pixy\'s topic list');
+        resolve(response);
+      });
+    });
+  }),{
+    maxTries: 10,
+    beforeWait: n => console.log('Try', n, 'topic existence', TOPIC1_NAME)
+  });
 
 };

--- a/example-nodejs-client/stack-setup.js
+++ b/example-nodejs-client/stack-setup.js
@@ -1,6 +1,43 @@
 // wait for services in ../build-contracts
+
+const {
+  PIXY_HOST = 'http://localhost:19090',
+  CACHE1_HOST = 'http://localhost:19081',
+  TOPIC1_NAME = 'topic1',
+  TEST_ID = '' + new Date().toISOString()
+} = process.env;
+
+const fetch = require('node-fetch');
+
+// retry on no connection, but not on any status code
+// There's node-fetch-retry and node-fetch-plus if we want libs
+const fetchRetry = async (url, opts) => {
+  let retry = opts && opts.retries || 3
+  while (retry > 0) {
+    try {
+      return await fetch(url, opts)
+    } catch(e) {
+      if (opts.retryCallback) {
+          opts.retryCallback(retry)
+      }
+      retry = retry - 1
+      if (retry == 0) {
+          throw e
+      }
+    }
+  }
+};
+
 module.exports = async function() {
   console.log(' Looking for test stack...');
-  await new Promise(resolve => setTimeout(resolve, 1));
-  throw new Error('Setup not implemented');
+
+  //test("Check that pixy is online at " + PIXY_HOST, async () => {
+  let response = await fetchRetry(PIXY_HOST, {
+    timeout: 3,
+    retries: 10,
+    retryCallback: retry => console.log(new Date(), 'Retrying pixy access', retry)
+  });
+  //expect(response.status).toEqual(404);
+  //});
+
 };

--- a/example-nodejs-client/stack-setup.js
+++ b/example-nodejs-client/stack-setup.js
@@ -1,0 +1,6 @@
+// wait for services in ../build-contracts
+module.exports = async function() {
+  console.log(' Looking for test stack...');
+  await new Promise(resolve => setTimeout(resolve, 1));
+  throw new Error('Setup not implemented');
+};


### PR DESCRIPTION
Even with `--runInBand` jest will randomize file order, meaning that every spec would need to do the wait for services. 