### PR TITLE
Add a --standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ See [the Node.js example](./example-nodejs-client/cache-update-flow.spec.js).
 
  * Topic keys must be deserializable as [String](https://kafka.apache.org/21/javadoc/org/apache/kafka/common/serialization/Serdes.html#String--) because these strings are used in REST URIs.
 
+## Running
+
+Docker builds are available at [docker.io/kafka/keyvalue](https://hub.docker.com/r/yolean/kafka-keyvalue).
+
+See examples of CLI args in [ArgsToOptionsTest](./src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java).
+
+For REST endpoints see `@Path` in [Endpoints](./src/main/java/se/yolean/kafka/keyvalue/Endpoints.java).
+
 ## Development
 
 The [build-contract](https://github.com/Yolean/build-contract/) can be used as dev stack.

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -107,9 +107,9 @@ services:
       curl --ipv4 --retry 5 --retry-connrefused -H 'User-Agent: curl-based-kafka-keyvalue-smoketest' http://onupdate-logging:8080/
       curl --ipv4 --retry 5 --retry-connrefused http://pixy:19090 -I
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081 -I
-      curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/healthz -f
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/metrics -f | grep consumer_metrics | grep incoming_byte_total
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/metrics -f | grep ^kkv_
+      curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/healthz -f
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/cache/v1/raw/smoketest1 -I
       curl --ipv4 --retry 5 --retry-connrefused http://pixy:19090/topics -f | grep topic1
       curl --ipv4 -d '{"x":1}' -H 'Content-Type: application/json' 'http://pixy:19090/topics/topic1/messages?key=smoketest1' -f

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -70,15 +70,14 @@ services:
     ports:
     - 19081:19081
     command:
+    - --standalone
+    - --application-id
+    -   kv-001-
     - --port
     -   '19081'
     - --streams-props
     -   bootstrap.servers=kafka:9092
     -   num.standby.replicas=0
-    - --hostname
-    -   cache1
-    - --application-id
-    -   kv-001
     - --topic
     -   topic1
     - --onupdate
@@ -133,3 +132,53 @@ services:
     command:
     # By design the cache service deals with a single topic, meaning that tests probably can't run concurrently
     - --runInBand
+
+  cache2-01:
+    depends_on:
+    - kafka
+    - topic2-create
+    image: yolean/kafka-keyvalue:dev
+    expose:
+    - '19082'
+    command:
+    - --port
+    -   '19082'
+    - --streams-props
+    -   bootstrap.servers=kafka:9092
+    # Not sure how to do this in docker-compose
+    #-   num.standby.replicas=1
+    - --hostname
+    -   cache2-01
+    - --application-id
+    -   kv-002
+    - --topic
+    -   topic2
+    - --onupdate
+    -   http://onupdate-logging:8080/sharded/01
+    - --starttimeout
+    -   '25'
+
+  cache2-02:
+    depends_on:
+    - kafka
+    - topic2-create
+    image: yolean/kafka-keyvalue:dev
+    expose:
+    - '19083'
+    command:
+    - --port
+    -   '19083'
+    - --streams-props
+    -   bootstrap.servers=kafka:9092
+    # Not sure how to do this in docker-compose
+    #-   num.standby.replicas=1
+    - --hostname
+    -   cache2-02
+    - --application-id
+    -   kv-002
+    - --topic
+    -   topic2
+    - --onupdate
+    -   http://onupdate-logging:8080/sharded/02
+    - --starttimeout
+    -   '25'

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   kafka:
     image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
-    links:
+    depends_on:
     - zookeeper
     entrypoint:
     - ./bin/kafka-server-start.sh
@@ -20,11 +20,6 @@ services:
     -   log.retention.hours=-1
     - --override
     -   log.dirs=/var/lib/kafka/data/topics
-    - --override
-    # Shouldn't be needed for streams, but currently for the test container(s) to produce data
-    -   auto.create.topics.enable=true
-    - --override
-    -   default.replication.factor=1
     - --override
     -   min.insync.replicas=1
     - --override
@@ -52,13 +47,22 @@ services:
     -  0.0.0.0:19090
 
   topic1-create:
-    image: solsson/kafkacat@sha256:b91241b5741fccaef282eb8dbdfb6e5289bb8586274175b1836e57912ffecaef
+    image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+    depends_on:
+    - kafka
     entrypoint:
-    - /bin/bash
-    - -c
+    - ./bin/kafka-topics.sh
     command:
-    - |
-      until kafkacat -b kafka:9092 -C -K '=' -t topic1 -e; do sleep 3; done
+    - --zookeeper
+    -   zookeeper:2181
+    - --topic
+    -   topic1
+    - --create
+    - --if-not-exists
+    - --partitions
+    -   '1'
+    - --replication-factor
+    -   '1'
 
   cache1:
     depends_on:
@@ -134,6 +138,24 @@ services:
     command:
     # By design the cache service deals with a single topic, meaning that tests probably can't run concurrently
     - --runInBand
+
+  topic2-create:
+    image: solsson/kafka:2.1.1@sha256:8bc8242c649c395ab79d76cc83b1052e63b4efea7f83547bf11eb3ef5ea6f8e1
+    depends_on:
+    - kafka
+    entrypoint:
+    - ./bin/kafka-topics.sh
+    command:
+    - --zookeeper
+    -   zookeeper:2181
+    - --topic
+    -   topic2
+    - --create
+    - --if-not-exists
+    - --partitions
+    -   '12'
+    - --replication-factor
+    -   '1'
 
   cache2-01:
     depends_on:

--- a/build-contracts/docker-compose.yml
+++ b/build-contracts/docker-compose.yml
@@ -107,7 +107,9 @@ services:
       curl --ipv4 --retry 5 --retry-connrefused -H 'User-Agent: curl-based-kafka-keyvalue-smoketest' http://onupdate-logging:8080/
       curl --ipv4 --retry 5 --retry-connrefused http://pixy:19090 -I
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081 -I
+      curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/healthz -f
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/metrics -f | grep consumer_metrics | grep incoming_byte_total
+      curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/metrics -f | grep ^kkv_
       curl --ipv4 --retry 5 --retry-connrefused http://cache1:19081/cache/v1/raw/smoketest1 -I
       curl --ipv4 --retry 5 --retry-connrefused http://pixy:19090/topics -f | grep topic1
       curl --ipv4 -d '{"x":1}' -H 'Content-Type: application/json' 'http://pixy:19090/topics/topic1/messages?key=smoketest1' -f

--- a/src/main/java/se/yolean/kafka/keyvalue/App.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/App.java
@@ -35,8 +35,10 @@ public class App {
 
     KeyvalueUpdate keyvalueUpdate = new KeyvalueUpdateProcessor(
         options.getTopicName(),
-        options.getOnUpdate());
-    logger.info("Processor created");
+        options.getOnUpdate(),
+        options.getStandalone());
+    logger.info("Processor created, standalone={} application-id={} input-topic={}",
+        options.getStandalone(), options.getApplicationId(), options.getTopicName());
 
     Topology topology = keyvalueUpdate.getTopology();
     logger.info("Topology created, starting Streams using {} custom props",

--- a/src/main/java/se/yolean/kafka/keyvalue/App.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/App.java
@@ -67,7 +67,7 @@ public class App {
         .registerResourceInstance(endpoints)
         .asServlet()
         .addCustomServlet(metricsServlet, "/metrics")
-        .addCustomServlet(new ReadinessServlet(keyvalueUpdate), "/ready")
+        .addCustomServlet(new ReadinessServlet(readiness), "/healthz")
         .create();
     logger.info("REST server created {}", server);
 

--- a/src/main/java/se/yolean/kafka/keyvalue/App.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/App.java
@@ -66,8 +66,8 @@ public class App {
         .registerResourceClass(org.glassfish.jersey.jackson.JacksonFeature.class)
         .registerResourceInstance(endpoints)
         .asServlet()
-        .addCustomServlet(metricsServlet, "/metrics")
-        .addCustomServlet(new ReadinessServlet(readiness), "/healthz")
+        .addCustomServlet(metricsServlet, PrometheusMetricsServlet.ENDPOINT_PATH)
+        .addCustomServlet(new ReadinessServlet(readiness), ReadinessServlet.ENDPOINT_PATH)
         .create();
     logger.info("REST server created {}", server);
 

--- a/src/main/java/se/yolean/kafka/keyvalue/App.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/App.java
@@ -60,6 +60,7 @@ public class App {
     logger.info("Starting REST service with endpoints {}", endpoints);
 
     PrometheusMetricsServlet metricsServlet = new PrometheusMetricsServlet(metrics);
+    ReadinessServlet readinessServlet = new ReadinessServlet();
 
     CacheServer server = new ConfigureRest()
         .createContext(options.getPort(), "/")
@@ -67,7 +68,7 @@ public class App {
         .registerResourceInstance(endpoints)
         .asServlet()
         .addCustomServlet(metricsServlet, PrometheusMetricsServlet.ENDPOINT_PATH)
-        .addCustomServlet(new ReadinessServlet(readiness), ReadinessServlet.ENDPOINT_PATH)
+        .addCustomServlet(readinessServlet, ReadinessServlet.ENDPOINT_PATH)
         .create();
     logger.info("REST server created {}", server);
 
@@ -87,6 +88,8 @@ public class App {
             logger.error("REST server shutdown failed", e);
           }
         });
+
+    readinessServlet.setReadiness(readiness);
   }
 
   public Readiness getReadiness() {

--- a/src/main/java/se/yolean/kafka/keyvalue/CacheServiceOptions.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/CacheServiceOptions.java
@@ -21,4 +21,6 @@ public interface CacheServiceOptions {
 
   Integer getStartTimeoutSecods();
 
+  boolean getStandalone();
+
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
@@ -299,4 +299,8 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
 
   }
 
+  void setInitTimestampForOnupdateSuppression(long processorInitTime) {
+    this.processorInitTime = processorInitTime;
+  }
+
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
@@ -1,5 +1,6 @@
 package se.yolean.kafka.keyvalue;
 
+import java.text.DateFormat;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -37,6 +38,8 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
       .name("kkv_onupdate_succeeded").help("Total on-update requests succeeded (after retries)").register();
   static final Counter onupdateFailed = Counter.build()
       .name("kkv_onupdate_failed").help("Total on-update requests failed (after retries)").register();
+  static final Counter onupdateSuppressed = Counter.build()
+      .name("kkv_onupdate_suppressed").labelNames("reason").help("Total on-update requests suppressed").register();
   static final Counter offsetsNotProcessed = Counter.build()
       .name("kkv_offsets_not_processed").help("The processor won't see null key messages, so we count gaps in the offset sequence"
           + ". But note that kafka offsets are not guaranteed to be sequencial: https://stackoverflow.com/a/54637004").register();
@@ -48,10 +51,13 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
   private static final String STATE_STORE_NAME = "Keyvalue";
 
   public static final Logger logger = LogManager.getLogger(KeyvalueUpdateProcessor.class);
+  private static final DateFormat TIMESTAMP_FORMATTER = new TimestampFormatter();
 
 	private String sourceTopicPattern;
   private OnUpdate onUpdate;
   private ProcessorContext context = null;
+
+  private long processorInitTime = -1;
 
   // We can't use this to build so we keep it for sanity checks
   private StoreBuilder<KeyValueStore<String, byte[]>> storeBuilder = null;
@@ -106,6 +112,8 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
     this.context = context;
     this.maintenance = new Maintenance();
     context.schedule(maintenance.getInterval(), PunctuationType.WALL_CLOCK_TIME, maintenance);
+    processorInitTime = System.currentTimeMillis();
+    logger.info("Proccessor start time is {} {}", processorInitTime, TIMESTAMP_FORMATTER.format(processorInitTime));
   }
 
   @Override
@@ -132,7 +140,7 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
   @Override
   public void process(String key, byte[] value) {
     logger.trace("Got keyvalue {}={}", key, new String(value));
-    UpdateRecord update = new UpdateRecord(context.topic(), context.partition(), context.offset(), key);
+    UpdateRecord update = new UpdateRecord(context.topic(), context.partition(), context.offset(), key, context.timestamp());
     if (key == null) {
       logger.debug("Ignoring null key at " + update);
       return;
@@ -147,10 +155,18 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
 
   private void process(UpdateRecord update, byte[] value) {
     store.put(update.getKey(), value);
-    OnUpdateCompletionLogging previous = latestPending.get(update.getTopicPartition());
-    OnUpdateCompletionLogging completion = new OnUpdateCompletionLogging(update, previous);
-    onUpdate.handle(update, completion);
-    latestPending.put(update.getTopicPartition(), completion);
+    if (update.getTimestamp() < processorInitTime) {
+      logger.debug("Suppressing onupdate for message {} t={} that predates processor start {}",
+          () -> update.toString(),
+          () -> TIMESTAMP_FORMATTER.format(update.getTimestamp()),
+          () -> TIMESTAMP_FORMATTER.format(processorInitTime));
+      onupdateSuppressed.labels("historic").inc();
+    } else {
+      OnUpdateCompletionLogging previous = latestPending.get(update.getTopicPartition());
+      OnUpdateCompletionLogging completion = new OnUpdateCompletionLogging(update, previous);
+      onUpdate.handle(update, completion);
+      latestPending.put(update.getTopicPartition(), completion);
+    }
   }
 
   @Override

--- a/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/KeyvalueUpdateProcessor.java
@@ -63,6 +63,8 @@ public class KeyvalueUpdateProcessor implements KeyvalueUpdate, Processor<String
       Serdes.String(),
       Serdes.ByteArray()
     );
+    // investigate https://github.com/Yolean/kafka-keyvalue/issues/24
+    storeBuilder.withLoggingDisabled();
   }
 
 	@Override

--- a/src/main/java/se/yolean/kafka/keyvalue/TimestampFormatter.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/TimestampFormatter.java
@@ -1,0 +1,26 @@
+package se.yolean.kafka.keyvalue;
+
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+
+/**
+ * Just to make sure we get UTC.
+ */
+public class TimestampFormatter extends SimpleDateFormat {
+
+  private static final String DEFAULT_FORMAT = "yyyyMMdd't'HHmmss";
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Sets a short human-readable timestamp useful for logging, application id etc.
+   */
+  public TimestampFormatter() {
+    this(DEFAULT_FORMAT);
+  }
+
+  public TimestampFormatter(String format) {
+    super(format);
+    setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
+
+}

--- a/src/main/java/se/yolean/kafka/keyvalue/UpdateRecord.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/UpdateRecord.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.TopicPartition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 @JsonPropertyOrder({"topic","partition","offset","key"})
 public class UpdateRecord implements Serializable {
@@ -65,6 +66,7 @@ public class UpdateRecord implements Serializable {
    * Timestamp is just a value we carry during processing, not serialized to clients
    * (at least not until we have a convincing use case for including it in onupdate).
    */
+  @JsonIgnore
   public long getTimestamp() {
     if (timestamp == NO_TIMESTAMP) {
       throw new IllegalStateException("The optional timestamp was requested when not set, for " + this);

--- a/src/main/java/se/yolean/kafka/keyvalue/UpdateRecord.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/UpdateRecord.java
@@ -13,11 +13,15 @@ public class UpdateRecord implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  private static final long NO_TIMESTAMP = -1;
+
   private final TopicPartition topicPartition;
   private final long offset;
   private final String key;
   private final String string;
   private final int hashCode;
+
+  private long timestamp = NO_TIMESTAMP;
 
   @JsonCreator
   public UpdateRecord(
@@ -30,6 +34,11 @@ public class UpdateRecord implements Serializable {
     this.key = key;
     this.string = topicPartition.toString() + '-' + offset + '[' + key + ']';
     this.hashCode = string.hashCode();
+  }
+
+  public UpdateRecord(String topic, int partition, long offset, String key, long timestamp) {
+    this(topic, partition, offset, key);
+    this.timestamp  = timestamp;
   }
 
   public String getTopic() {
@@ -50,6 +59,17 @@ public class UpdateRecord implements Serializable {
 
   TopicPartition getTopicPartition() {
     return topicPartition;
+  }
+
+  /**
+   * Timestamp is just a value we carry during processing, not serialized to clients
+   * (at least not until we have a convincing use case for including it in onupdate).
+   */
+  public long getTimestamp() {
+    if (timestamp == NO_TIMESTAMP) {
+      throw new IllegalStateException("The optional timestamp was requested when not set, for " + this);
+    }
+    return timestamp;
   }
 
   @Override

--- a/src/main/java/se/yolean/kafka/keyvalue/cli/ArgsToOptions.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/cli/ArgsToOptions.java
@@ -1,6 +1,7 @@
 package se.yolean.kafka.keyvalue.cli;
 
 import static net.sourceforge.argparse4j.impl.Arguments.store;
+import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +18,7 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.Namespace;
 import se.yolean.kafka.keyvalue.CacheServiceOptions;
 import se.yolean.kafka.keyvalue.OnUpdate;
+import se.yolean.kafka.keyvalue.TimestampFormatter;
 import se.yolean.kafka.keyvalue.onupdate.OnUpdateWithExternalPollTrigger;
 
 public class ArgsToOptions implements CacheServiceOptions {
@@ -30,6 +32,9 @@ public class ArgsToOptions implements CacheServiceOptions {
    * {@value #DEFAULT_ONUPDATE_RETRIES}
    */
   public static final int DEFAULT_ONUPDATE_RETRIES = 0;
+
+  public static final String STANDALONE_MODE_APPLICATION_ID_TIMESTAMP =
+      new TimestampFormatter().format(System.currentTimeMillis());
 
   private String topicName = null;
   private Integer port = null;
@@ -134,7 +139,7 @@ public class ArgsToOptions implements CacheServiceOptions {
             + " Set to >0 to enable a check after this many seconds.");
 
     parser.addArgument("--standalone")
-        .action(store())
+        .action(storeTrue())
         .required(false)
         .type(Boolean.class)
         .metavar("STANDALONE")
@@ -194,6 +199,10 @@ public class ArgsToOptions implements CacheServiceOptions {
             throw new IllegalArgumentException("Invalid property: " + prop);
           props.put(pieces[0], pieces[1]);
         }
+      }
+
+      if (standalone) {
+        applicationId = applicationId.concat(hostName).concat("-").concat(STANDALONE_MODE_APPLICATION_ID_TIMESTAMP);
       }
 
       props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);

--- a/src/main/java/se/yolean/kafka/keyvalue/http/ConfigureRest.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/ConfigureRest.java
@@ -34,6 +34,7 @@ public class ConfigureRest {
       public Servlets addCustomServlet(HttpServlet servlet, String pathSpec) {
         ServletHolder holder = new ServletHolder(servlet);
         context.addServlet(holder, pathSpec);
+        logger.info("Added custom servlet with pathSpec {}: {}", pathSpec, servlet);
         return this;
       }
 
@@ -58,7 +59,7 @@ public class ConfigureRest {
         // https://stackoverflow.com/a/50269323
         // https://github.com/eclipse-ee4j/jersey/issues/3700
         resourceConfig.register(component);
-        logger.debug("Registered resource component {}", component);
+        logger.info("Registered resource component {}", component);
         return this;
       }
 
@@ -67,7 +68,7 @@ public class ConfigureRest {
         ServletContainer sc = new ServletContainer(resourceConfig);
         ServletHolder holder = new ServletHolder(sc);
         context.addServlet(holder, RESOURCE_SERVLET_PATHSPEC);
-        logger.debug("Added REST servlet with pathSpec {}", RESOURCE_SERVLET_PATHSPEC);
+        logger.info("Added REST servlet with pathSpec {}", RESOURCE_SERVLET_PATHSPEC);
         return servlets;
       }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/http/ReadinessServlet.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/ReadinessServlet.java
@@ -12,8 +12,12 @@ import se.yolean.kafka.keyvalue.Readiness;
 
 /**
  * Based on the example in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request
+ *
+ * Path: {@value #ENDPOINT_PATH}
  */
 public class ReadinessServlet extends HttpServlet {
+
+  public static final String ENDPOINT_PATH = "/healthz";
 
   public static final String READINESS_CONTENT_TYPE = "application/json";
   public static final byte[] READY_JSON = "{\"ready\":true}".getBytes();

--- a/src/main/java/se/yolean/kafka/keyvalue/http/ReadinessServlet.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/ReadinessServlet.java
@@ -3,6 +3,7 @@ package se.yolean.kafka.keyvalue.http;
 import java.io.IOException;
 
 import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -13,6 +14,10 @@ import se.yolean.kafka.keyvalue.Readiness;
  * Based on the example in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request
  */
 public class ReadinessServlet extends HttpServlet {
+
+  public static final String READINESS_CONTENT_TYPE = "application/json";
+  public static final byte[] READY_JSON = "{\"ready\":true}".getBytes();
+  public static final byte[] UNREADY_JSON = "{\"ready\":false}".getBytes();
 
   private static final long serialVersionUID = 1L;
 
@@ -35,10 +40,18 @@ public class ReadinessServlet extends HttpServlet {
     }
     if (readiness.isAppReady()) {
       resp.setStatus(200);
-      resp.setContentLength(0);
-      resp.getOutputStream().close();
+      resp.setContentLength(READY_JSON.length);
+      resp.setContentType(READINESS_CONTENT_TYPE);
+      ServletOutputStream body = resp.getOutputStream();
+      body.write(READY_JSON);
+      body.close();
     } else {
-      resp.sendError(500);
+      resp.setStatus(500);
+      resp.setContentLength(UNREADY_JSON.length);
+      resp.setContentType(READINESS_CONTENT_TYPE);
+      ServletOutputStream body = resp.getOutputStream();
+      body.write(UNREADY_JSON);
+      body.close();
     }
   }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/http/ReadinessServlet.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/ReadinessServlet.java
@@ -7,16 +7,19 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import se.yolean.kafka.keyvalue.KafkaCache;
+import se.yolean.kafka.keyvalue.Readiness;
 
+/**
+ * Based on the example in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request
+ */
 public class ReadinessServlet extends HttpServlet {
 
   private static final long serialVersionUID = 1L;
 
-  private KafkaCache cache;
+  private Readiness readiness;
 
-  public ReadinessServlet(KafkaCache cache) {
-    this.cache = cache;
+  public ReadinessServlet(Readiness readiness) {
+    this.readiness = readiness;
   }
 
   @Override
@@ -26,14 +29,16 @@ public class ReadinessServlet extends HttpServlet {
 
   @Override
   protected void doHead(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-    if (cache == null) {
-      resp.setStatus(503);
+    if (readiness == null) {
+      resp.sendError(503);
       return;
     }
-    if (cache.isReady()) {
-      resp.setStatus(204);
+    if (readiness.isAppReady()) {
+      resp.setStatus(200);
+      resp.setContentLength(0);
+      resp.getOutputStream().close();
     } else {
-      resp.setStatus(412); // TODO what's the recommended status code for unready? 503 might be misleading in proxied setups.
+      resp.sendError(500);
     }
   }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/metrics/MetricsPrint.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/metrics/MetricsPrint.java
@@ -1,0 +1,40 @@
+package se.yolean.kafka.keyvalue.metrics;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+
+public class MetricsPrint {
+
+  private CollectorRegistry registry;
+
+  public MetricsPrint(CollectorRegistry registry) {
+    this.registry = registry;
+  }
+
+  public MetricsPrint() {
+    this(CollectorRegistry.defaultRegistry);
+  }
+
+  public void print(OutputStream out, Set<String> names) {
+    OutputStreamWriter osw = new OutputStreamWriter(out, Charset.defaultCharset());
+    // https://github.com/prometheus/client_java/blob/parent-0.6.0/simpleclient_httpserver/src/main/java/io/prometheus/client/exporter/HTTPServer.java#L59
+    try {
+      TextFormat.write004(osw, registry.filteredMetricFamilySamples(names));
+      osw.append('\n');
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public void printAll(OutputStream out) {
+    print(out, new HashSet<String>(0));
+  }
+
+}

--- a/src/main/java/se/yolean/kafka/keyvalue/metrics/PrometheusMetricsServlet.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/metrics/PrometheusMetricsServlet.java
@@ -8,9 +8,14 @@ import javax.servlet.http.HttpServletResponse;
 
 import io.prometheus.client.exporter.MetricsServlet;
 
+/**
+ * {@value #ENDPOINT_PATH}
+ */
 public class PrometheusMetricsServlet extends MetricsServlet {
 
   private static final long serialVersionUID = 1L;
+
+  public static final String ENDPOINT_PATH = "/metrics";
 
   private StreamsMetrics streamsMetrics;
 

--- a/src/test/java/se/yolean/kafka/keyvalue/TimestampFormatterTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/TimestampFormatterTest.java
@@ -1,0 +1,17 @@
+package se.yolean.kafka.keyvalue;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.text.DateFormat;
+
+import org.junit.jupiter.api.Test;
+
+class TimestampFormatterTest {
+
+  @Test
+  void test() {
+    DateFormat formatter = new TimestampFormatter();
+    assertEquals("20190309t122836", formatter.format(1552134516000L));
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java
@@ -48,6 +48,7 @@ class ArgsToOptionsTest {
   void testOnupdateMany() {
     String args = "--port 19082"
         + " --streams-props bootstrap.servers=localhost:19092"
+        + " --hostname mypod-abcde"
         + " --topic topic2"
         + " --application-id kv-test1-001"
         + " --onupdate http://127.0.0.1:8081/updated http://127.0.0.1:8082/updates"

--- a/src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/cli/ArgsToOptionsTest.java
@@ -1,10 +1,10 @@
 package se.yolean.kafka.keyvalue.cli;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -66,6 +66,25 @@ class ArgsToOptionsTest {
       }
     };
     assertNotNull(options.getOnUpdate());
+    assertFalse(options.getStandalone());
+  }
+
+  @Test
+  void testStandalone() {
+    String args = "--standalone"
+        + " --hostname pod-12345678-abcde"
+        + " --application-id kv-"
+        + " --streams-props bootstrap.servers=bootstrap.kafka:9092"
+        + " --topic topic3"
+        + " --onupdate http://myservice/updates";
+    CacheServiceOptions options = new ArgsToOptions(args.split("\\s+"));
+    assertTrue(options.getStandalone());
+    assertTrue(options.getApplicationId().length() > 22,
+        "Standalone mode should append to application id");
+    assertEquals("kv-pod-12345678-abcde-", options.getApplicationId().substring(0, 22),
+        "Standalone mode should append hostname and timestamp to application id");
+    assertTrue(Pattern.matches(".*-abcde-20[0-9]{6}t[0-1][0-9]{5}$", options.getApplicationId()),
+        "Timestamp should be around now, got " + options.getApplicationId());
   }
 
 }

--- a/src/test/java/se/yolean/kafka/keyvalue/http/JettyCacheServerIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/JettyCacheServerIntegrationTest.java
@@ -1,6 +1,6 @@
 package se.yolean.kafka.keyvalue.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
 
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import se.yolean.kafka.keyvalue.CacheServiceOptions;
-import se.yolean.kafka.keyvalue.KafkaCache;
 import se.yolean.kafka.keyvalue.Readiness;
 
 class JettyCacheServerIntegrationTest {

--- a/src/test/java/se/yolean/kafka/keyvalue/http/JettyCacheServerIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/JettyCacheServerIntegrationTest.java
@@ -51,7 +51,7 @@ class JettyCacheServerIntegrationTest {
         .registerResourceClass(org.glassfish.jersey.jackson.JacksonFeature.class)
         .registerResourceInstance(endpoints)
         .asServlet()
-        .addCustomServlet(new ReadinessServlet(readiness), "/healthz")
+        .addCustomServlet(new ReadinessServlet().setReadiness(readiness), "/healthz")
         .create();
     server.start();
 

--- a/src/test/java/se/yolean/kafka/keyvalue/onupdate/OnUpdateWithExternalPollTriggerTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/onupdate/OnUpdateWithExternalPollTriggerTest.java
@@ -1,7 +1,14 @@
 package se.yolean.kafka.keyvalue.onupdate;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -9,7 +16,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.AsyncInvoker;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;


### PR DESCRIPTION
I never implemented support for sharded instances, the way https://github.com/bakdata/kafka-key-value-store https://medium.com/bakdata/queryable-kafka-topics-with-kafka-streams-8d2cca9de33f did.

Until we have a use case for sharding I'd like to explore a sidecar-friendly full-keyspace mode. Scope:

- Leave no litter behind on brokers, except a consumer group offset (which will expire as per broker configuration)
- Don't send onupdate requests when reading from zero (fixes #20)
- Be ready only when representing the full key space (fixes #24)

WIP