### PR TITLE
Retry when Kafka connection fails, or is lost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,12 @@ COPY --from=maven-build /workspace/target/*-runner.jar ./
 
 # from Quarkus' maven plugin mvn package -Pnative -Dnative-image.docker-build=true
 RUN native-image \
+  -J-Dsun.nio.ch.maxUpdateArraySize=100 \
   -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager \
+  -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory \
+  -J-Dvertx.disableDnsResolver=true \
+  -J-Dio.netty.leakDetection.level=DISABLED \
+  -J-Dio.netty.allocator.maxOrder=1 \
   --initialize-at-build-time= \
   # commented out due to "Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated."
   #-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime \
@@ -89,7 +94,6 @@ RUN native-image \
   -H:+PrintAnalysisCallTree \
   -H:-AddAllCharsets \
   -H:EnableURLProtocols=http \
-  -H:-SpawnIsolates \
   -H:+JNI \
   --no-server \
   -H:-UseServiceLoaderFeature \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ ARG SOURCE_COMMIT
 ARG SOURCE_BRANCH
 ARG IMAGE_NAME
 
+RUN apk add --no-cache snappy snappy lz4 zstd
+
 WORKDIR /app
 COPY --from=maven-build /workspace/target/lib ./lib
 COPY --from=maven-build /workspace/target/*-runner.jar ./quarkus-kafka.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY . .
 #RUN mvn -o package
 RUN mvn -o package -DskipTests
 
-FROM adoptopenjdk/openjdk11:x86_64-ubi-minimal-jre-11.0.5_10@sha256:211be858640892f5bd24a17b229420e115c046f624380ca046ec26517c5f51f1 \
+FROM fabric8/java-alpine-openjdk8-jre@sha256:a5d31f17d618032812ae85d12426b112279f02951fa92a7ff8a9d69a6d3411b1 \
   as runtime-plainjava
 ARG SOURCE_COMMIT
 ARG SOURCE_BRANCH
@@ -94,7 +94,7 @@ RUN native-image \
   -H:+StackTrace
 
 # The rest should be identical to src/main/docker/Dockerfile which is the recommended quarkus build
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c505667389712dc337986e29ffcb65116879ef27629dc3ce6e1b17727c06e78f
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:32fb8bae553bfba2891f535fa9238f79aafefb7eff603789ba8920f505654607
 ARG SOURCE_COMMIT
 ARG SOURCE_BRANCH
 ARG IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM maven:3.6.2-jdk-8-slim@sha256:2b54b5981f55838fc4fba956e0092bc97b932ef011c7f70ca85caec337711741 as maven
+FROM maven:3.6.3-jdk-8-slim@sha256:d8e01825867d1e4ddbb96e40b5f08183e2a7d7ff40521c49cd8e76e36d75d340 as maven
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.4_11-slim@sha256:79f43f49f505df27528a3dce52e30339116ed6716b1f658206ba76caca26c85b \
+FROM adoptopenjdk/openjdk11:jdk-11.0.5_10-slim@sha256:b3cc66d2cdd34b4e02ad245985961abd407d37f4c2850dfd83d49a821ec417d7 \
   as dev
 
 COPY --from=maven /usr/share/maven /usr/share/maven
@@ -25,7 +25,7 @@ COPY . .
 ENTRYPOINT [ "mvn", "compile", "quarkus:dev" ]
 CMD [ "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.http.port=8090" ]
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.4_11-slim@sha256:79f43f49f505df27528a3dce52e30339116ed6716b1f658206ba76caca26c85b \
+FROM adoptopenjdk/openjdk11:jdk-11.0.5_10-slim@sha256:b3cc66d2cdd34b4e02ad245985961abd407d37f4c2850dfd83d49a821ec417d7 \
   as maven-build
 
 COPY --from=maven /usr/share/maven /usr/share/maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG=/root/.m2
 
 WORKDIR /workspace
-RUN mvn io.quarkus:quarkus-maven-plugin:0.28.1:create \
+RUN mvn io.quarkus:quarkus-maven-plugin:1.0.0.Final:create \
     -DprojectGroupId=org.example.temp \
     -DprojectArtifactId=kafka-quickstart \
     -Dextensions="kafka" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG=/root/.m2
 
 WORKDIR /workspace
-RUN mvn io.quarkus:quarkus-maven-plugin:1.0.0.Final:create \
+RUN mvn io.quarkus:quarkus-maven-plugin:1.0.1.Final:create \
     -DprojectGroupId=org.example.temp \
     -DprojectArtifactId=kafka-quickstart \
     -Dextensions="kafka" && \

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.salesforce.kafka.test</groupId>
       <artifactId>kafka-junit5</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>0.28.1</quarkus.version>
+    <quarkus.version>1.0.0.Final</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>1.0.0.Final</quarkus.version>
+    <quarkus.version>1.0.1.Final</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,19 +6,24 @@
   <artifactId>kafka-keyvalue</artifactId>
   <version>1.0-SNAPSHOT</version>
   <properties>
-    <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <quarkus.version>1.0.1.Final</quarkus.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <quarkus-plugin.version>1.0.1.Final</quarkus-plugin.version>
+    <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
+    <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
+    <quarkus.platform.version>1.0.1.Final</quarkus.platform.version>
+    <surefire-plugin.version>2.22.1</surefire-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${quarkus.version}</version>
+        <groupId>${quarkus.platform.group-id}</groupId>
+        <artifactId>${quarkus.platform.artifact-id}</artifactId>
+        <version>${quarkus.platform.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -95,7 +100,7 @@
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
-        <version>${quarkus.version}</version>
+        <version>${quarkus-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -103,6 +108,10 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${compiler-plugin.version}</version>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -126,21 +135,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-maven-plugin</artifactId>
-            <version>${quarkus.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>native-image</goal>
-                </goals>
-                <configuration>
-                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>${surefire-plugin.version}</version>
             <executions>
@@ -159,6 +153,9 @@
           </plugin>
         </plugins>
       </build>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -7,15 +7,25 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/kafka-keyvalue-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/kafka-quickstart-jvm .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/kafka-keyvalue-jvm
+# docker run -i --rm -p 8080:8080 quarkus/kafka-quickstart-jvm
 #
 ###
-FROM fabric8/java-jboss-openjdk8-jdk
-ENV JAVA_OPTIONS=-Dquarkus.http.host=0.0.0.0
+FROM fabric8/java-alpine-openjdk8-jre
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar
+EXPOSE 8080
+
+# run with user 1001 and be prepared for be running in OpenShift too
+RUN adduser -G root --no-create-home --disabled-password 1001 \
+  && chown -R 1001 /deployments \
+  && chmod -R "g+rwX" /deployments \
+  && chown -R 1001:root /deployments
+USER 1001
+
 ENTRYPOINT [ "/deployments/run-java.sh" ]

--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -3,18 +3,18 @@
 #
 # Before building the docker image run:
 #
-# mvn package -Pnative -Dnative-image.docker-build=true
+# mvn package -Pnative -Dquarkus.native.container-build=true
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/kafka-keyvalue .
+# docker build -f src/main/docker/Dockerfile.native -t quarkus/kafka-quickstart .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/kafka-keyvalue
+# docker run -i --rm -p 8080:8080 quarkus/kafka-quickstart
 #
 ###
-FROM registry.fedoraproject.org/fedora-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -59,7 +59,9 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
     Resetting (60),
     InitialPoll (70),
     PollingHistorical (80),
-    Polling (90);
+    Polling (90),
+    ConnectionLost (100),
+    Reconnecting (110);
 
     final int metricValue;
     Stage(int metricValue) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 
 quarkus.log.category."se.yolean".level=DEBUG
 quarkus.log.category."org.apache.kafka.clients.Metadata".level=DEBUG
+
+quarkus.ssl.native=false

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
@@ -142,7 +142,7 @@ public class ErrorHandlingIntegrationTest {
         } catch (InterruptedException e) {
           fail(e);
         }
-        //throw error;
+        throw error;
       }
     };
 
@@ -163,17 +163,17 @@ public class ErrorHandlingIntegrationTest {
 
     StartupEvent startup = Mockito.mock(StartupEvent.class);
     consumer.start(startup);
-    Thread.sleep(10);
+    Thread.sleep(TIMEOUT / 2);
     assertEquals(1, runs.size());
     Thread.sleep(TIMEOUT);
 
     consumer.call(); // Readiness probe
-    Thread.sleep(10);
+    Thread.sleep(50);
     assertEquals(2, runs.size());
     Thread.sleep(TIMEOUT);
 
     consumer.call(); // Readiness probe
-    Thread.sleep(10);
+    Thread.sleep(TIMEOUT / 2);
     assertEquals(3, runs.size());
     Thread.sleep(TIMEOUT);
 
@@ -181,12 +181,12 @@ public class ErrorHandlingIntegrationTest {
     consumer.stop(shutdown);
 
     consumer.call(); // Readiness probe
-    Thread.sleep(1);
+    Thread.sleep(TIMEOUT / 2);
     assertEquals(3, runs.size());
     Thread.sleep(TIMEOUT);
 
     consumer.call(); // Readiness probe
-    Thread.sleep(1);
+    Thread.sleep(TIMEOUT / 2);
     assertEquals(3, runs.size());
     Thread.sleep(TIMEOUT);
   }

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
@@ -80,7 +80,7 @@ public class ErrorHandlingIntegrationTest {
       assertEquals("Timeout expired while fetching topic metadata", e.getMessage());
       assertEquals(org.apache.kafka.common.errors.TimeoutException.class, e.getClass());
     }
-    assertTrue(System.currentTimeMillis() - t1 > 20, "Should have spent time waiting for metadata timeout twice");
+    assertTrue(System.currentTimeMillis() - t1 > 10, "Should have spent time waiting for metadata timeout");
     assertTrue(System.currentTimeMillis() - t1 < 500, "Should have exited after metadata timeout, not waited for other things");
 
     assertFalse(consumer.isReady(),

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
@@ -1,0 +1,92 @@
+package se.yolean.kafka.keyvalue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.salesforce.kafka.test.KafkaBroker;
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+
+import se.yolean.kafka.keyvalue.ConsumerAtLeastOnce.Stage;
+
+public class ErrorHandlingIntegrationTest {
+
+  @RegisterExtension
+  static final SharedKafkaTestResource kafka = new SharedKafkaTestResource().withBrokers(1);
+
+  Properties getConsumerProperties(String bootstrap, String groupId) {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+    // use latest here to allow many test cases to use the same topic (though all test cases keys' will be read to cache)
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+    return props;
+  }
+
+  Properties getTestProducerProperties(String bootstrap) {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+    props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, CompressionType.NONE.name);
+    return props;
+  }
+
+  @Test
+  void testBrokerDisconnect() throws Exception {
+
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    final String TOPIC = "topic1";
+    final String GROUP = this.getClass().getSimpleName() + "_testBrokerDisconnect_" + System.currentTimeMillis();
+    final String BOOTSTRAP = kafka.getKafkaConnectString();
+    kafka.getKafkaTestUtils().createTopic("topic1", 3, (short) 1);
+
+    consumer.consumerProps = getConsumerProperties(BOOTSTRAP, GROUP);
+    consumer.onupdate = Mockito.mock(OnUpdate.class);
+    consumer.cache = new HashMap<>();
+    consumer.topics = Collections.singletonList(TOPIC);
+
+    consumer.maxPolls = 5;
+    consumer.metadataTimeout = Duration.ofSeconds(10); // TODO tests fail on an assertion further down if this is too short, there's no produce error
+    consumer.pollDuration = Duration.ofMillis(100);
+    consumer.minPauseBetweenPolls = Duration.ofMillis(100);
+
+    KafkaProducer<String, byte[]> producer = new KafkaProducer<>(getTestProducerProperties(BOOTSTRAP));
+    producer.send(new ProducerRecord<String,byte[]>(TOPIC, "k1", "v1".getBytes())).get();
+
+    consumer.consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest"); // start from scratch even if we're reusing a test topic
+    consumer.run();
+    consumer.consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none"); // the test should fail if we don't have an offset after the first run
+
+    assertEquals(Stage.Polling, consumer.stage); // To be able to see where we exited we're not resetting stage at the end of runs
+
+    assertEquals(1, consumer.cache.size(), "Should be operational now, before we mess with connections");
+
+    KafkaBroker broker = kafka.getKafkaBrokers().iterator().next();
+
+    broker.stop();
+    consumer.run();
+
+    producer.close();
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
@@ -55,10 +55,10 @@ public class ErrorHandlingIntegrationTest {
   void testBrokerDisconnect() throws Exception {
 
     ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
-    final String TOPIC = "topic1";
+    final String TOPIC = "topicx";
     final String GROUP = this.getClass().getSimpleName() + "_testBrokerDisconnect_" + System.currentTimeMillis();
     final String BOOTSTRAP = kafka.getKafkaConnectString();
-    kafka.getKafkaTestUtils().createTopic("topic1", 3, (short) 1);
+    kafka.getKafkaTestUtils().createTopic("topicx", 3, (short) 1);
 
     consumer.consumerProps = getConsumerProperties(BOOTSTRAP, GROUP);
     consumer.onupdate = Mockito.mock(OnUpdate.class);
@@ -85,6 +85,12 @@ public class ErrorHandlingIntegrationTest {
 
     broker.stop();
     consumer.run();
+
+    broker.start();
+    producer.send(new ProducerRecord<String,byte[]>(TOPIC, "k2", "v1".getBytes())).get();
+    consumer.run();
+
+    assertEquals(1, consumer.cache.size(), "Should be operational now, before we mess with connections");
 
     producer.close();
   }

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
@@ -1,0 +1,98 @@
+package se.yolean.kafka.keyvalue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.salesforce.kafka.test.KafkaBroker;
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+
+import se.yolean.kafka.keyvalue.ConsumerAtLeastOnce.Stage;
+
+public class ErrorHandlingKafkaIntegrationTest {
+
+  @RegisterExtension
+  static final SharedKafkaTestResource kafka = new SharedKafkaTestResource().withBrokers(1);
+
+  Properties getConsumerProperties(String bootstrap, String groupId) {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+    // use latest here to allow many test cases to use the same topic (though all test cases keys' will be read to cache)
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+    return props;
+  }
+
+  Properties getTestProducerProperties(String bootstrap) {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+    props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, CompressionType.NONE.name);
+    return props;
+  }
+
+  @Test
+  void testBrokerDisconnect() throws Exception {
+
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    final String TOPIC = "topicx";
+    final String GROUP = this.getClass().getSimpleName() + "_testBrokerDisconnect_" + System.currentTimeMillis();
+    final String BOOTSTRAP = kafka.getKafkaConnectString();
+    kafka.getKafkaTestUtils().createTopic("topicx", 3, (short) 1);
+
+    consumer.consumerProps = getConsumerProperties(BOOTSTRAP, GROUP);
+    consumer.onupdate = Mockito.mock(OnUpdate.class);
+    consumer.cache = new HashMap<>();
+    consumer.topics = Collections.singletonList(TOPIC);
+
+    consumer.maxPolls = 5;
+    consumer.metadataTimeout = Duration.ofSeconds(10); // TODO tests fail on an assertion further down if this is too short, there's no produce error
+    consumer.pollDuration = Duration.ofMillis(100);
+    consumer.minPauseBetweenPolls = Duration.ofMillis(100);
+
+    KafkaProducer<String, byte[]> producer = new KafkaProducer<>(getTestProducerProperties(BOOTSTRAP));
+    producer.send(new ProducerRecord<String,byte[]>(TOPIC, "k1", "v1".getBytes())).get();
+
+    consumer.consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest"); // start from scratch even if we're reusing a test topic
+    consumer.run();
+    consumer.consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none"); // the test should fail if we don't have an offset after the first run
+
+    assertEquals(Stage.Polling, consumer.stage); // To be able to see where we exited we're not resetting stage at the end of runs
+
+    assertEquals(1, consumer.cache.size(), "Should be operational now, before we mess with connections");
+
+    KafkaBroker broker = kafka.getKafkaBrokers().iterator().next();
+
+    broker.stop();
+    consumer.run();
+
+    broker.start();
+    producer.send(new ProducerRecord<String,byte[]>(TOPIC, "k2", "v1".getBytes())).get();
+    consumer.run();
+
+    assertEquals(1, consumer.cache.size(), "Should be operational now, before we mess with connections");
+
+    producer.close();
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
@@ -66,7 +66,7 @@ public class ErrorHandlingKafkaIntegrationTest {
     consumer.topics = Collections.singletonList(TOPIC);
 
     consumer.maxPolls = 5;
-    consumer.metadataTimeout = Duration.ofMillis(500);
+    consumer.metadataTimeout = Duration.ofMillis(2000);
     consumer.pollDuration = Duration.ofMillis(100);
     consumer.minPauseBetweenPolls = Duration.ofMillis(100);
 

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
@@ -66,7 +66,7 @@ public class ErrorHandlingKafkaIntegrationTest {
     consumer.topics = Collections.singletonList(TOPIC);
 
     consumer.maxPolls = 5;
-    consumer.metadataTimeout = Duration.ofSeconds(10); // TODO tests fail on an assertion further down if this is too short, there's no produce error
+    consumer.metadataTimeout = Duration.ofMillis(500);
     consumer.pollDuration = Duration.ofMillis(100);
     consumer.minPauseBetweenPolls = Duration.ofMillis(100);
 


### PR DESCRIPTION
Until Quarkus has sorted out shutdown (watch https://github.com/quarkusio/quarkus/search?p=2&q=shutdown&type=Issues) we can't rely on Pod restart and should therefore do retries.