### PR TITLE
Fix Dockerized native build with Quarkus > 0.25.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,11 @@ COPY --from=maven-build /workspace/target/*-runner.jar ./
 # from Quarkus' maven plugin mvn package -Pnative -Dnative-image.docker-build=true
 RUN native-image \
   -J-Djava.util.logging.manager=org.jboss.logmanager.LogManager \
+  -J-Dsun.nio.ch.maxUpdateArraySize=100 \
+  -J-Dio.netty.leakDetection.level=DISABLED \
+  -J-Dio.netty.allocator.maxOrder=1 \
+  -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory \
+  -J-Dvertx.disableDnsResolver=true \
   --initialize-at-build-time= \
   # commented out due to "Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated."
   #-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ RUN native-image \
   -J-Dio.netty.leakDetection.level=DISABLED \
   -J-Dio.netty.allocator.maxOrder=1 \
   --initialize-at-build-time= \
+  # added because of build issues, https://github.com/Yolean/kafka-keyvalue/pull/36
   --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslContext \
   --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslEngine \
   # commented out due to "Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated."
@@ -99,6 +100,7 @@ RUN native-image \
   -H:+JNI \
   --no-server \
   -H:-UseServiceLoaderFeature \
+  -H:+TraceClassInitialization \
   -H:+StackTrace
 
 # The rest should be identical to src/main/docker/Dockerfile which is the recommended quarkus build

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,9 +85,6 @@ RUN native-image \
   -J-Dio.netty.leakDetection.level=DISABLED \
   -J-Dio.netty.allocator.maxOrder=1 \
   --initialize-at-build-time= \
-  # added because of build issues, https://github.com/Yolean/kafka-keyvalue/pull/36
-  --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslContext \
-  --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslEngine \
   # commented out due to "Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated."
   #-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime \
   -jar kafka-keyvalue-1.0-SNAPSHOT-runner.jar \
@@ -96,7 +93,8 @@ RUN native-image \
   -H:+ReportExceptionStackTraces \
   -H:+PrintAnalysisCallTree \
   -H:-AddAllCharsets \
-  -H:EnableURLProtocols=http \
+  -H:EnableURLProtocols=http,https \
+  --enable-all-security-services \
   -H:+JNI \
   --no-server \
   -H:-UseServiceLoaderFeature \

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,7 @@ RUN native-image \
   -H:+ReportExceptionStackTraces \
   -H:+PrintAnalysisCallTree \
   -H:-AddAllCharsets \
-  -H:EnableURLProtocols=http,https \
-  --enable-all-security-services \
+  -H:EnableURLProtocols=http \
   -H:+JNI \
   --no-server \
   -H:-UseServiceLoaderFeature \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.6.3-jdk-8-slim@sha256:d8e01825867d1e4ddbb96e40b5f08183e2a7d7ff40521c49cd8e76e36d75d340 as maven
 
-FROM adoptopenjdk/openjdk8:jdk8u232-b09-slim@sha256:3031fe397a55c182dc709c1d54529e58ef49c10c3becbc5eafc5dc9a9cf3ce4d \
+FROM openjdk:8-jdk-slim@sha256:71592a5c3eecf243b624f0a718402bb54d9ccb282b3ae3aa108f62b5cd5539d1 \
   as dev
 
 COPY --from=maven /usr/share/maven /usr/share/maven
@@ -25,7 +25,7 @@ COPY . .
 ENTRYPOINT [ "mvn", "compile", "quarkus:dev" ]
 CMD [ "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.http.port=8090" ]
 
-FROM adoptopenjdk/openjdk8:jdk8u232-b09-slim@sha256:3031fe397a55c182dc709c1d54529e58ef49c10c3becbc5eafc5dc9a9cf3ce4d \
+FROM openjdk:8-jdk-slim@sha256:71592a5c3eecf243b624f0a718402bb54d9ccb282b3ae3aa108f62b5cd5539d1 \
   as maven-build
 
 COPY --from=maven /usr/share/maven /usr/share/maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ RUN native-image \
   -J-Dvertx.logger-delegate-factory-class-name=io.quarkus.vertx.core.runtime.VertxLogDelegateFactory \
   -J-Dvertx.disableDnsResolver=true \
   --initialize-at-build-time= \
+  --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslContext \
+  --initialize-at-run-time=io.netty.handler.ssl.ReferenceCountedOpenSslEngine \
   # commented out due to "Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated."
   #-H:InitialCollectionPolicy=com.oracle.svm.core.genscavenge.CollectionPolicy$BySpaceAndTime \
   -jar kafka-keyvalue-1.0-SNAPSHOT-runner.jar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.6.3-jdk-8-slim@sha256:d8e01825867d1e4ddbb96e40b5f08183e2a7d7ff40521c49cd8e76e36d75d340 as maven
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.5_10-slim@sha256:b3cc66d2cdd34b4e02ad245985961abd407d37f4c2850dfd83d49a821ec417d7 \
+FROM adoptopenjdk/openjdk8:jdk8u232-b09-slim@sha256:3031fe397a55c182dc709c1d54529e58ef49c10c3becbc5eafc5dc9a9cf3ce4d \
   as dev
 
 COPY --from=maven /usr/share/maven /usr/share/maven
@@ -25,7 +25,7 @@ COPY . .
 ENTRYPOINT [ "mvn", "compile", "quarkus:dev" ]
 CMD [ "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.http.port=8090" ]
 
-FROM adoptopenjdk/openjdk11:jdk-11.0.5_10-slim@sha256:b3cc66d2cdd34b4e02ad245985961abd407d37f4c2850dfd83d49a821ec417d7 \
+FROM adoptopenjdk/openjdk8:jdk8u232-b09-slim@sha256:3031fe397a55c182dc709c1d54529e58ef49c10c3becbc5eafc5dc9a9cf3ce4d \
   as maven-build
 
 COPY --from=maven /usr/share/maven /usr/share/maven

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN set -e; \
   cat native-image.sh | sed 's| | \\\n  |g'
 
 FROM fabric8/java-alpine-openjdk8-jre@sha256:a5d31f17d618032812ae85d12426b112279f02951fa92a7ff8a9d69a6d3411b1 \
-  as runtime-plainjava
+  as runtime-jre
 ARG SOURCE_COMMIT
 ARG SOURCE_BRANCH
 ARG IMAGE_NAME

--- a/hooks/build
+++ b/hooks/build
@@ -4,6 +4,12 @@ set -e
 echo "------ HOOK START - BUILD -------"
 printenv
 
-docker build -t $IMAGE_NAME --build-arg SOURCE_COMMIT=$SOURCE_COMMIT --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg IMAGE_NAME=$IMAGE_NAME .
+docker build -t $IMAGE_NAME-plainjava --target runtime-plainjava \
+  --build-arg SOURCE_COMMIT=$SOURCE_COMMIT --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg IMAGE_NAME=$IMAGE_NAME  .
+
+docker build -t $IMAGE_NAME \
+  --build-arg SOURCE_COMMIT=$SOURCE_COMMIT --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg IMAGE_NAME=$IMAGE_NAME .
+
+[ ! -z "$SOURCE_COMMIT" ] && docker push $IMAGE_NAME-plainjava
 
 echo "------ HOOK END   - BUILD -------"

--- a/hooks/build
+++ b/hooks/build
@@ -4,12 +4,12 @@ set -e
 echo "------ HOOK START - BUILD -------"
 printenv
 
-docker build -t $IMAGE_NAME-plainjava --target runtime-plainjava \
+docker build -t $IMAGE_NAME-jre --target runtime-jre \
   --build-arg SOURCE_COMMIT=$SOURCE_COMMIT --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg IMAGE_NAME=$IMAGE_NAME  .
 
 docker build -t $IMAGE_NAME \
   --build-arg SOURCE_COMMIT=$SOURCE_COMMIT --build-arg SOURCE_BRANCH=$SOURCE_BRANCH --build-arg IMAGE_NAME=$IMAGE_NAME .
 
-[ ! -z "$SOURCE_COMMIT" ] && docker push $IMAGE_NAME-plainjava
+[ ! -z "$SOURCE_COMMIT" ] && docker push $IMAGE_NAME-jre
 
 echo "------ HOOK END   - BUILD -------"

--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 echo "------ HOOK START - BUILD -------"
 printenv

--- a/push-for-autobuild.sh
+++ b/push-for-autobuild.sh
@@ -1,1 +1,0 @@
-git checkout build-plainjava && git rebase master && git push -f solsson build-plainjava && git checkout master && git push solsson master

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 
 quarkus.log.category."se.yolean".level=DEBUG
 quarkus.log.category."org.apache.kafka.clients.Metadata".level=DEBUG
+
+quarkus.ssl.native=false


### PR DESCRIPTION
Quarkus has https://quarkus.io/guides/building-native-image#creating-a-container-with-a-multi-stage-docker-build but in my experience native builds are too heavy and complex to run inside something as heavy and complex as maven builds. I'd rather keep trying to follow the updates to Quarkus' `mvn package -Pnative`.

As observed in #35 builds fail now however.