### PR TITLE
Ignore null key records

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,7 @@ RUN mvn package -Dmaven.test.skip=true
 # For a regular JRE image run: docker build --build-arg build="package" --target=jvm
 ARG build="package -Pnative"
 
-RUN mvn --batch-mode $build | tee build.log; \
-  set -ex; \
-  grep '[INFO] BUILD SUCCESS' build.log || \
-    grep 'Native memory allocation (mmap) failed\|Exit code was 137 which indicates an out of memory error' build.log && \
-    grep --color=never 'NativeImageBuildStep] /opt/graalvm' build.log | cut -d ' ' -f 3- | \
-      (cd target/*-source-jar; sh - ); \
-  rm build.log
+RUN mvn --batch-mode $build
 
 FROM yolean/java:f63772d02556021dbcb9f49fb9eff3d3dbe1b636@sha256:1bc5b3456a64fb70c85825682777c55a0999d9be56aca9bb1f507fe9b9171f83 \
   as jvm

--- a/hooks/build
+++ b/hooks/build
@@ -1,5 +1,6 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+[ -z "$DEBUG" ] || set -x
+set -eo pipefail
 
 GIT_STATUS=$(git status --untracked-files=no --porcelain=v2)
 [ ! -z "$SOURCE_COMMIT" ] || export SOURCE_COMMIT=$(git rev-parse --verify HEAD)

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-metrics</artifactId>
+      <artifactId>quarkus-micrometer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -309,14 +309,14 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
         toStats(update);
         if (update.getKey() != null) {
           cache.put(record.key(), record.value());
-        } else {
-          onNullKey(update);
         }
         Long start = nextUncommitted.get(update.getTopicPartition());
         if (start == null) {
           throw new IllegalStateException("There's no start offset for " + update.getTopicPartition() + ", at consumed offset " + update.getOffset() + " key " + update.getKey());
         }
-        if (update.getKey() != null && record.offset() >= start) {
+        if (update.getKey() == null) {
+          onNullKeyUpdate(update);
+        } else if (record.offset() >= start) {
           onupdate.handle(update);
         } else {
           if (record.offset() == start - 1) {
@@ -349,7 +349,7 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
   }
 
   @Counted(name = "kkv_null_keys", description = "Counts records that have been ignored due to a null key")
-  void onNullKey(UpdateRecord update) {
+  void onNullKeyUpdate(UpdateRecord update) {
     logger.error("Ignoring null key at {}", update);
   }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -122,8 +122,8 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
   private final Counter meterNullKeys;
 
   public ConsumerAtLeastOnce(MeterRegistry registry) {
-    registry.gauge("kkv_stage", this, ConsumerAtLeastOnce::getStageMetric);
-    this.meterNullKeys = registry.counter("kkv_null_keys");
+    registry.gauge("kkv.stage", this, ConsumerAtLeastOnce::getStageMetric);
+    this.meterNullKeys = registry.counter("kkv.null.keys");
   }
 
   Integer getStageMetric() {

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -312,7 +312,7 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
         } else {
           onNullKey(update);
         }
-		    Long start = nextUncommitted.get(update.getTopicPartition());
+        Long start = nextUncommitted.get(update.getTopicPartition());
         if (start == null) {
           throw new IllegalStateException("There's no start offset for " + update.getTopicPartition() + ", at consumed offset " + update.getOffset() + " key " + update.getKey());
         }

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -307,16 +307,16 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
         ConsumerRecord<String, byte[]> record = records.next();
         UpdateRecord update = new UpdateRecord(record.topic(), record.partition(), record.offset(), record.key());
         toStats(update);
-        if (update.getKey() == null) {
+        if (update.getKey() != null) {
+          cache.put(record.key(), record.value());
+        } else {
           onNullKey(update);
-          continue;
         }
-        cache.put(record.key(), record.value());
 		    Long start = nextUncommitted.get(update.getTopicPartition());
         if (start == null) {
           throw new IllegalStateException("There's no start offset for " + update.getTopicPartition() + ", at consumed offset " + update.getOffset() + " key " + update.getKey());
         }
-        if (record.offset() >= start) {
+        if (update.getKey() != null && record.offset() >= start) {
           onupdate.handle(update);
         } else {
           if (record.offset() == start - 1) {

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -316,15 +316,17 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
         toStats(update);
         if (update.getKey() != null) {
           cache.put(record.key(), record.value());
-        } else {
-          onNullKey(update);
         }
         Long start = nextUncommitted.get(update.getTopicPartition());
         if (start == null) {
           throw new IllegalStateException("There's no start offset for " + update.getTopicPartition() + ", at consumed offset " + update.getOffset() + " key " + update.getKey());
         }
-        if (update.getKey() != null && record.offset() >= start) {
-          onupdate.handle(update);
+        if (record.offset() >= start) {
+          if (update.getKey() != null) {
+            onupdate.handle(update);
+          } else {
+            onNullKey(update);
+          }
         } else {
           if (record.offset() == start - 1) {
             logger.info("Reached last historical message for {} at offset {}", update.getTopicPartition(), update.getOffset());

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -316,14 +316,14 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
         toStats(update);
         if (update.getKey() != null) {
           cache.put(record.key(), record.value());
+        } else {
+          onNullKey(update);
         }
         Long start = nextUncommitted.get(update.getTopicPartition());
         if (start == null) {
           throw new IllegalStateException("There's no start offset for " + update.getTopicPartition() + ", at consumed offset " + update.getOffset() + " key " + update.getKey());
         }
-        if (update.getKey() == null) {
-          onNullKeyUpdate(update);
-        } else if (record.offset() >= start) {
+        if (update.getKey() != null && record.offset() >= start) {
           onupdate.handle(update);
         } else {
           if (record.offset() == start - 1) {
@@ -355,7 +355,7 @@ public class ConsumerAtLeastOnce implements KafkaCache, Runnable,
     currentOffsets.put(update.getTopicPartition(), update.getOffset());
   }
 
-  void onNullKeyUpdate(UpdateRecord update) {
+  void onNullKey(UpdateRecord update) {
     meterNullKeys.increment();
     logger.error("Ignoring null key at {}", update);
   }

--- a/src/main/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSON.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSON.java
@@ -27,7 +27,7 @@ import javax.json.JsonWriter;
 import se.yolean.kafka.keyvalue.UpdateRecord;
 
 // NOTE javax.json is unfit for what this class tried to do -- incrementally update a JSON.
-// Unless we find a lib that is designed to keep state as json, not on-off conversions of object trees,
+// Unless we find a lib that is designed to keep state as json, not one-off conversions of object trees,
 // we should drop this impl and go for the object tree strategy
 public class UpdatesBodyPerTopicJSON implements UpdatesBodyPerTopic {
 

--- a/src/main/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSON.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSON.java
@@ -82,6 +82,9 @@ public class UpdatesBodyPerTopicJSON implements UpdatesBodyPerTopic {
     if (offsetsBuilt != null) {
       throw new IllegalStateException("This update has already been retrieved for dispatch and can no longer be updated");
     }
+    if (update.getKey() == null) {
+      throw new IllegalArgumentException("Null key rejected, partition " + update.getPartition() + " offset " + update.getOffset());
+    }
     offsets.add(Integer.toString(update.getPartition()), Json.createValue(update.getOffset()));
     updates.add(update.getKey(), JsonObject.EMPTY_JSON_OBJECT);
   }

--- a/src/test/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnceIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnceIntegrationTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
 
 import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import se.yolean.kafka.keyvalue.ConsumerAtLeastOnce.Stage;
 
 public class ConsumerAtLeastOnceIntegrationTest {
@@ -72,7 +73,7 @@ public class ConsumerAtLeastOnceIntegrationTest {
   @Test
   void testSingleRun() throws InterruptedException, ExecutionException {
 
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry());
     final String TOPIC = "topic1";
     final String GROUP = this.getClass().getSimpleName() + "_testSingleRun_" + System.currentTimeMillis();
     final String BOOTSTRAP = kafka.getKafkaConnectString();
@@ -162,7 +163,7 @@ public class ConsumerAtLeastOnceIntegrationTest {
   @Test
   void testTopicNonexistent() throws InterruptedException, ExecutionException {
 
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry());
     final String TOPIC = "test-nonexistence";
     final String GROUP = this.getClass().getSimpleName() + "_testTopicNonexistent_" + System.currentTimeMillis();
     final String BOOTSTRAP = kafka.getKafkaConnectString();
@@ -194,7 +195,7 @@ public class ConsumerAtLeastOnceIntegrationTest {
   @Test
   void testNoOffsetReset() {
 
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry());
     final String TOPIC = "test-nooffsetreset";
     final String GROUP = this.getClass().getSimpleName() + "_testNoOffsetReset_" + System.currentTimeMillis();
     final String BOOTSTRAP = kafka.getKafkaConnectString();

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import se.yolean.kafka.keyvalue.ConsumerAtLeastOnce.Stage;
@@ -56,7 +57,7 @@ public class ErrorHandlingIntegrationTest {
   @Test
   void testMetadataTimeout() throws InterruptedException, ExecutionException {
 
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry());
     final String TOPIC = "topic1";
     final String GROUP = this.getClass().getSimpleName() + "_testMetadataTimeout_" + System.currentTimeMillis();
     final String BOOTSTRAP = bootstrap;
@@ -90,7 +91,7 @@ public class ErrorHandlingIntegrationTest {
 
   @Test
   void testIsAlive() throws InterruptedException {
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce() {
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry()) {
       @Override
       public void run() {
         try {
@@ -107,7 +108,7 @@ public class ErrorHandlingIntegrationTest {
 
   @Test
   void testIsAliveAfterException() throws InterruptedException {
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce() {
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry()) {
       @Override
       public void run() {
         try {
@@ -131,7 +132,7 @@ public class ErrorHandlingIntegrationTest {
 
     // Based on that this behavior is asserted above
     RuntimeException error = new org.apache.kafka.common.errors.TimeoutException();
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce() {
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry()) {
       @Override void topicsFromConfig() {}
       @Override
       public void run() {

--- a/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ErrorHandlingKafkaIntegrationTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import com.salesforce.kafka.test.KafkaBroker;
 import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import se.yolean.kafka.keyvalue.ConsumerAtLeastOnce.Stage;
 
 public class ErrorHandlingKafkaIntegrationTest {
@@ -54,7 +55,7 @@ public class ErrorHandlingKafkaIntegrationTest {
   @Test
   void testBrokerDisconnect() throws Exception {
 
-    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce();
+    ConsumerAtLeastOnce consumer = new ConsumerAtLeastOnce(new SimpleMeterRegistry());
     final String TOPIC = "topicx";
     final String GROUP = this.getClass().getSimpleName() + "_testBrokerDisconnect_" + System.currentTimeMillis();
     final String BOOTSTRAP = kafka.getKafkaConnectString();

--- a/src/test/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSONTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSONTest.java
@@ -76,7 +76,11 @@ class UpdatesBodyPerTopicJSONTest {
   @Test
   public void testNullKey() {
     UpdatesBodyPerTopicJSON body = new UpdatesBodyPerTopicJSON("t");
-    body.handle(new UpdateRecord("t", 0, 1234, null));
+    try {
+      body.handle(new UpdateRecord("t", 0, 1234, null));
+    } catch (IllegalArgumentException e) {
+      assertEquals("Null key rejected, partition 0 offset 1234", e.getMessage());
+    }
   }
 
 }

--- a/src/test/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSONTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/onupdate/UpdatesBodyPerTopicJSONTest.java
@@ -73,4 +73,10 @@ class UpdatesBodyPerTopicJSONTest {
     }
   }
 
+  @Test
+  public void testNullKey() {
+    UpdatesBodyPerTopicJSON body = new UpdatesBodyPerTopicJSON("t");
+    body.handle(new UpdateRecord("t", 0, 1234, null));
+  }
+
 }


### PR DESCRIPTION
Fixes #40. Rationale:
- It's an error to have a null key in a "table" topic (thus the ERROR log level).
- We don't wan't crashloops, thus there's a new counter `kkv_null_keys_total` to alert on.

Build from this branch: `yolean/kafka-keyvalue:6f7b9d8d88e7f9392497c9f33b1364a47da29793@sha256:bfb3fc1416f48bd55fe8eb45077dc0b4954202f52e5f0d5ca7ea1d13be72fa60`
