### PR TITLE
Make the values endpoint streaming again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.8.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.10.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>

--- a/src/main/java/se/yolean/kafka/keyvalue/http/CacheResource.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/CacheResource.java
@@ -182,17 +182,18 @@ public class CacheResource implements HealthCheck {
     requireUpToDateCache();
     Iterator<byte[]> values = cache.getValues();
 
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-
-    while (values.hasNext()) {
-      buffer.write(values.next());
-      buffer.write('\n');
-    }
-
-    ResponseBuilder response = Response.ok(buffer);
-
+    StreamingOutput stream = new StreamingOutput() {
+      @Override
+      public void write(OutputStream out) throws IOException, WebApplicationException {
+        while (values.hasNext()) {
+          out.write(values.next());
+          out.write('\n');
+        }
+      }
+    };
+    ResponseBuilder response = Response.ok(stream);
+    // REVIEW do we know that offsets haven't changes since we retrieved values?
     applyOffsetHeaders(response);
-
     return response.build();
   }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/http/CacheResource.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/CacheResource.java
@@ -173,7 +173,6 @@ public class CacheResource implements HealthCheck {
 
   /**
    * @return Newline separated values (no keys)
-   * @throws IOException
    */
   @GET()
   @Path("/values")
@@ -181,6 +180,9 @@ public class CacheResource implements HealthCheck {
   public Response values() throws IOException {
     requireUpToDateCache();
     Iterator<byte[]> values = cache.getValues();
+
+    ResponseBuilder response = Response.status(200);
+    applyOffsetHeaders(response);
 
     StreamingOutput stream = new StreamingOutput() {
       @Override
@@ -191,9 +193,8 @@ public class CacheResource implements HealthCheck {
         }
       }
     };
-    ResponseBuilder response = Response.ok(stream);
-    // REVIEW do we know that offsets haven't changes since we retrieved values?
-    applyOffsetHeaders(response);
+
+    response.entity(stream);
     return response.build();
   }
 

--- a/src/main/java/se/yolean/kafka/keyvalue/http/ValuesResponse.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/ValuesResponse.java
@@ -1,0 +1,18 @@
+package se.yolean.kafka.keyvalue.http;
+
+import java.util.Iterator;
+import java.util.List;
+
+import se.yolean.kafka.keyvalue.TopicPartitionOffset;
+
+public final class ValuesResponse {
+
+  final Iterator<byte[]> values;
+  final List<TopicPartitionOffset> currentOffsets;
+
+  public ValuesResponse(Iterator<byte[]> values, List<TopicPartitionOffset> currentOffsets) {
+    this.values = values;
+    this.currentOffsets = currentOffsets;
+  }
+
+}

--- a/src/main/java/se/yolean/kafka/keyvalue/http/ValuesResponseWriter.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/ValuesResponseWriter.java
@@ -1,0 +1,42 @@
+package se.yolean.kafka.keyvalue.http;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import se.yolean.kafka.keyvalue.onupdate.UpdatesBodyPerTopic;
+
+@Provider
+public class ValuesResponseWriter implements MessageBodyWriter<ValuesResponse> {
+
+  @Inject
+  ObjectMapper objectMapper;
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return type == ValuesResponse.class;
+  }
+
+  @Override
+  public void writeTo(ValuesResponse v, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+      MultivaluedMap<String, Object> httpHeaders, OutputStream out)
+      throws IOException, WebApplicationException {
+    String offsetsJson = objectMapper.writeValueAsString(v.currentOffsets);
+    httpHeaders.add(UpdatesBodyPerTopic.HEADER_PREFIX + "last-seen-offsets", offsetsJson);
+    while (v.values.hasNext()) {
+      out.write(v.values.next());
+      out.write('\n');
+    }
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/http/CacheResourceTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/CacheResourceTest.java
@@ -22,6 +22,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.StreamingOutput;
+
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponse.Status;
 import org.junit.jupiter.api.Test;
@@ -56,7 +58,14 @@ class CacheResourceTest {
     rest.mapper = new ObjectMapper();
     Mockito.when(rest.cache.isReady()).thenReturn(true);
     Mockito.when(rest.cache.getValues()).thenReturn(List.of("a".getBytes(), "b".getBytes()).iterator());
-    assertEquals("a\nb\n", rest.values().getEntity().toString());
+    StreamingOutput r = null;
+    try {
+      r = (StreamingOutput) rest.values().getEntity();
+    } catch (ClassCastException e) {
+      fail("Not a streaming response? " + rest.values());
+    }
+    // TODO can we assert on StreamingOutput body without a REST endpoint test framework?
+    // assertEquals("a\nb\n", rest.values().getEntity().toString());
   }
 
   @Test

--- a/src/test/java/se/yolean/kafka/keyvalue/http/ValuesResponseWriterTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/ValuesResponseWriterTest.java
@@ -1,0 +1,40 @@
+package se.yolean.kafka.keyvalue.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import se.yolean.kafka.keyvalue.TopicPartitionOffset;
+
+public class ValuesResponseWriterTest {
+
+  @Test
+  void testWrite() throws IOException {
+    ValuesResponse response = new ValuesResponse(
+        List.of("a".getBytes(), "b".getBytes()).iterator(),
+        List.of(new TopicPartitionOffset("mytopic", 0, 0L))
+      );
+
+    ValuesResponseWriter w = new ValuesResponseWriter();
+    w.objectMapper = new ObjectMapper();
+    assertTrue(w.isWriteable(response.getClass(), null, null, null));
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+    w.writeTo(response, null, null, null, null, headers, out);
+    assertEquals("[x-kkv-last-seen-offsets]", "" + headers.keySet());
+    assertEquals("[{\"offset\":0,\"partition\":0,\"topic\":\"mytopic\"}]", headers.getFirst("x-kkv-last-seen-offsets"));
+    assertEquals("a\nb\n", out.toString());
+  }
+
+}


### PR DESCRIPTION
This avoids memory usage spikes when retrieving large values responses. Reverts parts of #48 but also reduces the test coverage that #48 introduced. I found no easy way to render a response body from the "entity" and I didn't feel like introducing a REST test framework for this change.