### PR TITLE
Restore values streaming to avoid memory spikes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.8.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.11.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>

--- a/src/main/java/se/yolean/kafka/keyvalue/http/IteratorLinesWriter.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/IteratorLinesWriter.java
@@ -1,0 +1,46 @@
+package se.yolean.kafka.keyvalue.http;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Provider
+public class IteratorLinesWriter implements MessageBodyWriter<Iterator<?>> {
+
+  @Inject
+  ObjectMapper objectMapper;
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return Iterator.class.isAssignableFrom(type);
+  }
+
+  @Override
+  public void writeTo(Iterator<?> values, Class<?> type, Type genericType, Annotation[] annotations,
+      MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+      throws IOException, WebApplicationException {
+    while (values.hasNext()) {
+      Object value = values.next();
+      if (value instanceof byte[]) {
+        entityStream.write((byte[]) value);
+      } else if (value instanceof String) {
+        entityStream.write(((String) value).getBytes());
+      } else {
+        entityStream.write(objectMapper.writeValueAsBytes(value));
+      }
+      entityStream.write('\n');
+    }
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/http/CacheResourceTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/CacheResourceTest.java
@@ -14,13 +14,15 @@
 
 package se.yolean.kafka.keyvalue.http;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponse.Status;
@@ -55,8 +57,10 @@ class CacheResourceTest {
     rest.cache = Mockito.mock(KafkaCache.class);
     rest.mapper = new ObjectMapper();
     Mockito.when(rest.cache.isReady()).thenReturn(true);
-    Mockito.when(rest.cache.getValues()).thenReturn(List.of("a".getBytes(), "b".getBytes()).iterator());
-    assertEquals("a\nb\n", rest.values().getEntity().toString());
+    final Iterator<byte[]> values = List.of("a".getBytes(), "b".getBytes()).iterator();
+    Mockito.when(rest.cache.getValues()).thenReturn(values);
+
+    assertTrue(rest.values().getEntity() == values);
   }
 
   @Test

--- a/src/test/java/se/yolean/kafka/keyvalue/http/IteratorLinesWriterTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/IteratorLinesWriterTest.java
@@ -1,0 +1,41 @@
+package se.yolean.kafka.keyvalue.http;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.ws.rs.WebApplicationException;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import groovyjarjarantlr.collections.List;
+
+public class IteratorLinesWriterTest {
+
+  @Test
+  public void testIsWriteable() throws WebApplicationException, IOException {
+    IteratorLinesWriter writer = new IteratorLinesWriter();
+    writer.objectMapper = new ObjectMapper();
+    assertTrue(writer.isWriteable(Iterator.class, null, null, null));
+    assertFalse(writer.isWriteable(List.class, null, null, null));
+    Iterator<?> values = java.util.List.of(
+        Map.of("key", "value"),
+        "abc".getBytes(),
+        "def"
+      ).iterator();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writer.writeTo(values, null, null, null, null, null, out);
+    String[] lines = out.toString().split("\n");
+    assertEquals("{\"key\":\"value\"}", lines[0]);
+    assertEquals("abc", lines[1]);
+    assertEquals("def", lines[2]);
+  }
+
+}


### PR DESCRIPTION
Reverts part of #48, replacing #50 which didn't work because i failed to set headers from the MessageBodyWriter.

`yolean/kafka-keyvalue:200e2895fd7562723a3a4ba550a713b4f3475988@sha256:6726fb143ce508635ff8949a0062c298d162fefeae34a78b07b5c3bdb1c2a572`

The reason for the slightly overscoped InteratorLinesWriter is that I couldn't find a convenient way for `isWriteable` to return true only for `Iterator<byte[]>`. In the scope of kafka-keyvalue I think this impl is fine, but it will take care of any Iterator + any content-type.