### PR TITLE
De-support topics emptied by retention, to fix unwanted readiness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.11.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.12.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
   </properties>

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -137,7 +137,6 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
 
   public boolean isReady() {
     if (readinessOkOnResetting && this.stage == Stage.Resetting) {
-      logger.info("Reporting readiness OK at phase Resetting, presumably low==high watermark");
       return true;
     }
     return stage == Stage.Polling;

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -109,6 +109,7 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
     registry.gauge("kkv.stage", this, ConsumerAtLeastOnce::getStageMetric);
     this.meterNullKeys = registry.counter("kkv.null.keys");
     this.meterIdenticalValues = registry.counter("kkv.identical.values");
+    registry.gauge("kkv.cache.keys", this.cache, Map::size);
 
     this.registry = registry;
   }

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -109,7 +109,6 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
     registry.gauge("kkv.stage", this, ConsumerAtLeastOnce::getStageMetric);
     this.meterNullKeys = registry.counter("kkv.null.keys");
     this.meterIdenticalValues = registry.counter("kkv.identical.values");
-    registry.gauge("kkv.cache.keys", this.cache, Map::size);
 
     this.registry = registry;
   }
@@ -130,6 +129,8 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
     logger.info("Cache: {}", cache);
 
     logger.debug("DEBUG which duration do we get?? {}", assignmentsTimeout.toSeconds());
+
+    getRegistry().gaugeCollectionSize("kkv.cache.keys", Tags.empty(), this.cache.keySet());
   }
 
   public void stop(@Observes ShutdownEvent ev) {

--- a/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnce.java
@@ -90,8 +90,6 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
 
   private Map<TopicPartition, Long> lowWaterMarkAtStart = null;
 
-  private boolean readinessOkOnResetting = false;
-
   private Set<String> topics = new HashSet<>();
 
   Stage stage = Stage.Created;
@@ -136,9 +134,6 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
   }
 
   public boolean isReady() {
-    if (readinessOkOnResetting && this.stage == Stage.Resetting) {
-      return true;
-    }
     return stage == Stage.Polling;
   }
 
@@ -205,7 +200,6 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
       }
       this.stage = Stage.Resetting;
       logger.info("Got assigned offset {} for {}; seeking to low water mark {}", position, partition, startOffset);
-      if (startOffset > 0) this.readinessOkOnResetting = true;
       consumer.seek(partition, startOffset);
     }
     onupdate.pollStart(topics);
@@ -240,7 +234,8 @@ public class ConsumerAtLeastOnce implements KafkaConsumerRebalanceListener, Kafk
           if (record.offset() == start - 1) {
             this.stage = Stage.Polling;
             logger.info("Reached last historical message for {} at offset {}", update.getTopicPartition(), update.getOffset());
-            this.readinessOkOnResetting = false;
+            // TODO do we want to restore this tracking from the old consumer logic?
+            // lastCommittedNotReached.remove(update.getTopicPartition());
           } else {
             this.stage = Stage.PollingHistorical;
           }

--- a/src/main/java/se/yolean/kafka/keyvalue/http/CacheResource.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/http/CacheResource.java
@@ -129,47 +129,14 @@ public class CacheResource implements HealthCheck {
    */
   @GET
   @Path("/keys")
-  public Response keys() {
+  public Response keys() throws IOException {
     requireUpToDateCache();
     Iterator<String> all = cache.getKeys();
 
-    StreamingOutput stream = new StreamingOutput() {
-      @Override
-      public void write(OutputStream out) throws IOException, WebApplicationException {
-        while (all.hasNext()) {
-          out.write(all.next().getBytes());
-          out.write('\n');
-        }
-      }
-    };
-    // note that we can't add headers here because that doesn't work with StreamingOutput, see values()
-    return Response.ok(stream).build();
-  }
-
-  /**
-   * All keys in this instance (none from the partitions not represented here).
-   */
-  @GET
-  @Path("/keys")
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response keysJson() {
-    requireUpToDateCache();
-    Iterator<String> all = cache.getKeys();
-
-    StreamingOutput stream = new StreamingOutput() {
-      @Override
-      public void write(OutputStream out) throws IOException, WebApplicationException {
-        JsonGenerator json = Json.createGenerator(out);
-        JsonGenerator list = json.writeStartArray();
-        while (all.hasNext()) {
-          list.write(all.next());
-        }
-        list.writeEnd();
-        json.close();
-      }
-    };
-    // note that we can't add headers here because that doesn't work with StreamingOutput, see values()
-    return Response.ok(stream).build();
+    ResponseBuilder response = Response.status(200);
+    applyOffsetHeaders(response);
+    response.entity(all);
+    return response.build();
   }
 
   /**

--- a/src/test/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnceTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnceTest.java
@@ -30,12 +30,12 @@ public class ConsumerAtLeastOnceTest {
 
     var registry = new SimpleMeterRegistry();
     var instance = new ConsumerAtLeastOnce(registry);
+    // TODO as we add more metrics these assertions must extract the value of an actual metric name
     assertFalse(registry.getMetersAsString().contains("17"), "Unexpected metrics: \n" + registry.getMetersAsString());
     instance.toStats(new UpdateRecord("mytopic", 0, 17, "key1", 100), false);
     assertTrue(registry.getMetersAsString().contains("17"), "Unexpected metrics: \n" + registry.getMetersAsString());
     instance.toStats(new UpdateRecord("mytopic", 0, 27, "key1", 100), false);
     assertFalse(registry.getMetersAsString().contains("17"), "Unexpected metrics: \n" + registry.getMetersAsString());
-    assertFalse(registry.getMetersAsString().contains("NaN"), "Unexpected metrics: \n" + registry.getMetersAsString());
     assertTrue(registry.getMetersAsString().contains("27"), "Unexpected metrics: \n" + registry.getMetersAsString());
     instance.toStats(new UpdateRecord("mytopic", 0, 30, "key1", 100), false);
     assertTrue(registry.getMetersAsString().contains("30"), "Unexpected metrics: \n" + registry.getMetersAsString());

--- a/src/test/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnceTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/ConsumerAtLeastOnceTest.java
@@ -30,6 +30,7 @@ public class ConsumerAtLeastOnceTest {
 
     var registry = new SimpleMeterRegistry();
     var instance = new ConsumerAtLeastOnce(registry);
+    // TODO metrics registered after initialization aren't here
     // TODO as we add more metrics these assertions must extract the value of an actual metric name
     assertFalse(registry.getMetersAsString().contains("17"), "Unexpected metrics: \n" + registry.getMetersAsString());
     instance.toStats(new UpdateRecord("mytopic", 0, 17, "key1", 100), false);

--- a/src/test/java/se/yolean/kafka/keyvalue/http/CacheResourceTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/http/CacheResourceTest.java
@@ -90,7 +90,7 @@ class CacheResourceTest {
   }
 
   @Test
-  void testKeysUnready() {
+  void testKeysUnready() throws IOException {
     CacheResource rest = new CacheResource();
     rest.cache = Mockito.mock(KafkaCache.class);
     Mockito.when(rest.cache.isReady()).thenReturn(false);
@@ -103,7 +103,7 @@ class CacheResourceTest {
   }
 
   @Test
-  void testKeysJsonUnready() {
+  void testKeysJsonUnready() throws IOException {
     CacheResource rest = new CacheResource();
     rest.cache = Mockito.mock(KafkaCache.class);
     Mockito.when(rest.cache.isReady()).thenReturn(false);

--- a/src/test/java/se/yolean/kafka/keyvalue/onupdate/OnUpdateForwarderTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/onupdate/OnUpdateForwarderTest.java
@@ -21,11 +21,14 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 class OnUpdateForwarderTest {
 
   @Test
   void testNoStart() {
-    OnUpdateForwarder forwarder = new OnUpdateForwarder();
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    OnUpdateForwarder forwarder = new OnUpdateForwarder(registry);
     try {
       forwarder.sendUpdates();
       fail("Should have thrown");
@@ -36,7 +39,8 @@ class OnUpdateForwarderTest {
 
   @Test
   void testTwoStarts() {
-    OnUpdateForwarder forwarder = new OnUpdateForwarder();
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    OnUpdateForwarder forwarder = new OnUpdateForwarder(registry);
     forwarder.pollStart(Collections.singleton("testtopic"));
     try {
       forwarder.pollStart(Collections.singleton("testtopic"));


### PR DESCRIPTION
Merging this deliberately reopens #44 because we have no such use cases anymore and the solution appears flawed (as both code comments and commit comments hinted)