### PR TITLE
Watcher handle graceful onclose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM docker.io/yolean/builder-quarkus:9e78afadc64b01ef70c00add6039f3f31e1c2542@sha256:c8fba1c08a1af43a7038f3337fe2af98aec15a7cf31c3dc12c39ade540c827f7 \
+FROM --platform=$TARGETPLATFORM docker.io/yolean/builder-quarkus:394fc7c4a84a1b54cf9558b44a6607911c01e6dc@sha256:27a3231275db6e47ad615a4c88f5550c52e902a4e3bcd3cad73fff4bab87bb84 \
   as jnilib
 
 # https://github.com/xerial/snappy-java/blob/master/src/main/java/org/xerial/snappy/OSInfo.java#L113
@@ -9,7 +9,7 @@ RUN set -ex; \
   mkdir -pv native/$LIBPATH; \
   cp -v /usr/lib/$ARCH-linux-gnu/jni/* native/$LIBPATH/
 
-FROM --platform=$TARGETPLATFORM docker.io/yolean/builder-quarkus:9e78afadc64b01ef70c00add6039f3f31e1c2542@sha256:c8fba1c08a1af43a7038f3337fe2af98aec15a7cf31c3dc12c39ade540c827f7 \
+FROM --platform=$TARGETPLATFORM docker.io/yolean/builder-quarkus:394fc7c4a84a1b54cf9558b44a6607911c01e6dc@sha256:27a3231275db6e47ad615a4c88f5550c52e902a4e3bcd3cad73fff4bab87bb84 \
   as dev
 
 COPY pom.xml .
@@ -38,7 +38,7 @@ ARG build="package -Pnative"
 
 RUN mvn --batch-mode $build
 
-FROM --platform=$TARGETPLATFORM docker.io/yolean/runtime-quarkus-ubuntu-jre:9e78afadc64b01ef70c00add6039f3f31e1c2542@sha256:4d8ed25a81daac1f0434081346fcad719be13fd8dfbf4a793821b22149d5b79e \
+FROM --platform=$TARGETPLATFORM docker.io/yolean/runtime-quarkus-ubuntu-jre:394fc7c4a84a1b54cf9558b44a6607911c01e6dc@sha256:257887716945e41ab02d45da2740a23c105731144893507cb10dc2be94a363bf \
   as jvm
 
 WORKDIR /app
@@ -50,7 +50,7 @@ ENTRYPOINT [ "java", \
   "-Djava.util.logging.manager=org.jboss.logmanager.LogManager", \
   "-jar", "quarkus-run.jar" ]
 
-FROM --platform=$TARGETPLATFORM docker.io/yolean/runtime-quarkus-ubuntu:177518b0a77298d34f0caf1d0fcdc13750c355a8@sha256:ccd94ad8f1b6d90aa90f5fa5efaf2db57b0d3e6a29faea84ab1edc5777a23c99
+FROM --platform=$TARGETPLATFORM docker.io/yolean/runtime-quarkus-ubuntu:394fc7c4a84a1b54cf9558b44a6607911c01e6dc@sha256:64d2e21c5f44d3e518a882d3b794805789fb25eba2d0cc31c597d703f943ca4d
 
 COPY --from=dev /workspace/target/*-runner /usr/local/bin/quarkus
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.0</quarkus.platform.version>
+    <quarkus.platform.version>3.6.3</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <x-test-exclude-groups>devservices</x-test-exclude-groups>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.4</quarkus.platform.version>
+    <quarkus.platform.version>3.6.7</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <x-test-exclude-groups>devservices</x-test-exclude-groups>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.7</quarkus.platform.version>
+    <quarkus.platform.version>3.6.8</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <x-test-exclude-groups>devservices</x-test-exclude-groups>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,25 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-kubernetes-client</artifactId>
     </dependency>
+    <!-- These are optional dependencies of kubernetes-client, needed for testcontainers k3s to work -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.77</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.77</version>
+      <scope>test</scope>
+    </dependency>
+    <!--  -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>k3s</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.6.3</quarkus.platform.version>
+    <quarkus.platform.version>3.6.4</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
     <x-test-exclude-groups>devservices</x-test-exclude-groups>

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -15,7 +15,7 @@ build:
     #   buildArgs:
     #     build: package
     custom:
-      buildCommand: y-build --opt target=jvm --opt build-arg:build=package
+      buildCommand: EXPORT_CACHE=false y-build --opt target=jvm --opt build-arg:build=package
       dependencies:
         dockerfile:
           path: ./Dockerfile

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcher.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcher.java
@@ -98,7 +98,7 @@ public class EndpointsWatcher {
     onTargetReadyConsumers.add(consumer);
   }
 
-  void handleEvent(Action action, Endpoints resource) {
+  synchronized void handleEvent(Action action, Endpoints resource) {
     logger.debug("endpoints watch received action: {}", action.toString());
     if (action.equals(Action.DELETED)) {
       clearEndpoints();

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcher.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcher.java
@@ -119,8 +119,14 @@ public class EndpointsWatcher {
       @Override
       public void onClose(WatcherException cause) {
         // REVIEW what is a reasonable strategy here?
-        logger.warn("Exiting application due to watch closed");
+        logger.warn("Exiting application due to watch exceptionally closed");
         logger.error(cause.getMessage());
+        Quarkus.asyncExit(11);
+      }
+
+      @Override
+      public void onClose() {
+        logger.warn("Exiting application due to graceful watch closed");
         Quarkus.asyncExit(11);
       }
     });

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcher.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcher.java
@@ -117,6 +117,13 @@ public class EndpointsWatcher {
       }
 
       @Override
+      public boolean reconnecting() {
+        boolean reconnecting = Watcher.super.reconnecting();
+        logger.warn("Watcher reconnecting {}", reconnecting);
+        return reconnecting;
+      }
+
+      @Override
       public void onClose(WatcherException cause) {
         // REVIEW what is a reasonable strategy here?
         logger.warn("Exiting application due to watch exceptionally closed");

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
@@ -6,17 +6,17 @@ import java.util.Optional;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithName;
 
-@ConfigMapping(prefix = "kkv")
+@ConfigMapping(prefix = "kkv.target.service")
 public interface EndpointsWatcherConfig {
 
   @WithName("namespace")
   public String namespace();
 
-  @WithName("target.service.name")
+  @WithName("name")
   public Optional<String> targetServiceName();
 
   /** @return How often the informer rebuilds it cache. */
-  @WithName("endpoints-watcher.resync-period")
-  public Duration resyncPeriod();
+  @WithName("informer-resync-period")
+  public Duration informerResyncPeriod();
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
@@ -1,5 +1,6 @@
 package se.yolean.kafka.keyvalue.kubernetes;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import io.smallrye.config.ConfigMapping;
@@ -11,7 +12,10 @@ public interface EndpointsWatcherConfig {
   @WithName("target.service.name")
   public Optional<String> targetServiceName();
 
-  @WithName("endpoints-watcher.watch-restart-delay-seconds")
-  public Integer watchRestartDelaySeconds();
+  @WithName("endpoints-watcher.watch-restart-delay-min")
+  public Duration watchRestartDelayMin();
+
+  @WithName("endpoints-watcher.watch-restart-delay-max")
+  public Duration watchRestartDelayMax();
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
@@ -9,13 +9,14 @@ import io.smallrye.config.WithName;
 @ConfigMapping(prefix = "kkv")
 public interface EndpointsWatcherConfig {
 
+  @WithName("namespace")
+  public String namespace();
+
   @WithName("target.service.name")
   public Optional<String> targetServiceName();
 
-  @WithName("endpoints-watcher.watch-restart-delay-min")
-  public Duration watchRestartDelayMin();
-
-  @WithName("endpoints-watcher.watch-restart-delay-max")
-  public Duration watchRestartDelayMax();
+  /** @return How often the informer rebuilds it cache. */
+  @WithName("endpoints-watcher.resync-period")
+  public Duration resyncPeriod();
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
@@ -5,10 +5,13 @@ import java.util.Optional;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithName;
 
-@ConfigMapping(prefix = "kkv.target.service")
+@ConfigMapping(prefix = "kkv")
 public interface EndpointsWatcherConfig {
 
-  @WithName("name")
+  @WithName("target.service.name")
   public Optional<String> targetServiceName();
+
+  @WithName("endpoints-watcher.watch-restart-delay-seconds")
+  public Integer watchRestartDelaySeconds();
 
 }

--- a/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherConfig.java
@@ -10,7 +10,7 @@ import io.smallrye.config.WithName;
 public interface EndpointsWatcherConfig {
 
   @WithName("namespace")
-  public String namespace();
+  public Optional<String> targetServiceNamespace();
 
   @WithName("name")
   public Optional<String> targetServiceName();

--- a/src/main/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclient.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclient.java
@@ -39,10 +39,10 @@ public class UpdatesDispatcherWebclient implements UpdatesDispatcher {
   private Counter countSuccess;
 
   void initMetrics(MeterRegistry registry) {
-    countFailures = Counter.builder("kkv.onupdate.failed")
+    countFailures = Counter.builder("kkv.target.update.failure")
       .description("Failures to confirm update of a target endpoint, after retries")
       .register(registry);
-    countSuccess = Counter.builder("kkv.onupdate.ok")
+    countSuccess = Counter.builder("kkv.target.update.ok")
       .description("Confirm updates of a target endpoint, after retries")
       .register(registry);
     countFailures.increment(0);

--- a/src/main/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclient.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclient.java
@@ -10,6 +10,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.buffer.Buffer;
@@ -28,21 +29,29 @@ public class UpdatesDispatcherWebclient implements UpdatesDispatcher {
 
   EndpointsWatcher watcher;
 
-  private MeterRegistry registry;
-
   @Inject
   UpdatesDispatcherWebclientConfig config;
 
   private final WebClient webClient;
 
-  static void initMetrics(MeterRegistry registry) {
-    registry.counter("kkv.target.update.failure").increment(0);
+  private Counter countFailures;
+
+  private Counter countSuccess;
+
+  void initMetrics(MeterRegistry registry) {
+    countFailures = Counter.builder("kkv.target.update.failure")
+      .description("Failures to confirm update of a target endpoint, after retries")
+      .register(registry);
+    countSuccess = Counter.builder("kkv.target.update.success")
+      .description("Confirm updates of a target endpoint, after retries")
+      .register(registry);
+    countFailures.increment(0);
+    countSuccess.increment(0);
   }
 
   @Inject
   public UpdatesDispatcherWebclient(Vertx vertx, MeterRegistry registry, EndpointsWatcher watcher) {
     this.webClient = WebClient.create(vertx);
-    this.registry = registry;
     this.watcher = watcher;
 
     initMetrics(registry);
@@ -76,6 +85,7 @@ public class UpdatesDispatcherWebclient implements UpdatesDispatcher {
       String name = entry.getValue();
 
       dispatch(json, headers, ip, config.targetServicePort()).subscribe().with(item -> {
+        countSuccess.increment();
         logger.info("Successfully sent update to {}", name);
       }, getDispatchFailureConsumer(name));
     });
@@ -91,7 +101,7 @@ public class UpdatesDispatcherWebclient implements UpdatesDispatcher {
 
   private Consumer<Throwable> getDispatchFailureConsumer(String name) {
     return (t) -> {
-      registry.counter("kkv.target.update.failure").increment();
+      countFailures.increment();
       logger.error("Failed to send update to " + name, t);
     };
   }

--- a/src/main/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclient.java
+++ b/src/main/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclient.java
@@ -39,10 +39,10 @@ public class UpdatesDispatcherWebclient implements UpdatesDispatcher {
   private Counter countSuccess;
 
   void initMetrics(MeterRegistry registry) {
-    countFailures = Counter.builder("kkv.target.update.failure")
+    countFailures = Counter.builder("kkv.onupdate.failed")
       .description("Failures to confirm update of a target endpoint, after retries")
       .register(registry);
-    countSuccess = Counter.builder("kkv.target.update.success")
+    countSuccess = Counter.builder("kkv.onupdate.ok")
       .description("Confirm updates of a target endpoint, after retries")
       .register(registry);
     countFailures.increment(0);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,12 +1,11 @@
 kkv:
-  namespace: ${NAMESPACE}
-  endpoints-watcher:
-    resync-period: ${INFORMER_RESYNC_PERIOD:5m}
   target:
     path: ${ON_UPDATE_PATH:/kafka-keyvalue/v1/updates}
     service:
       name: ${TARGET_SERVICE_NAME:}
       port: ${TARGET_SERVICE_PORT:8080}
+      namespace: ${TARGET_SERVICE_NAMESPACE}
+      informer-resync-period: ${INFORMER_RESYNC_PERIOD:5m}
     static:
       host: ${TARGET_STATIC_HOST:}
       port: ${TARGET_STATIC_PORT:8080}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,7 +4,7 @@ kkv:
     service:
       name: ${TARGET_SERVICE_NAME:}
       port: ${TARGET_SERVICE_PORT:8080}
-      namespace: ${TARGET_SERVICE_NAMESPACE}
+      namespace: ${TARGET_SERVICE_NAMESPACE:}
       informer-resync-period: ${INFORMER_RESYNC_PERIOD:5m}
     static:
       host: ${TARGET_STATIC_HOST:}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,8 +52,10 @@ quarkus:
         level: DEBUG
       "io.fabric8.kubernetes.client":
         level: DEBUG
+        min-level: DEBUG
       "io.vertx.core.http":
         level: DEBUG
+        min-level: DEBUG
 
   kafka:
     snappy:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 kkv:
+  namespace: ${NAMESPACE}
   endpoints-watcher:
-    watch-restart-delay-min: ${WATCH_RESTART_DELAY_MIN:1ms}
-    watch-restart-delay-max: ${WATCH_RESTART_DELAY_MAX:60s}
+    resync-period: ${INFORMER_RESYNC_PERIOD:5m}
   target:
     path: ${ON_UPDATE_PATH:/kafka-keyvalue/v1/updates}
     service:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,6 @@
 kkv:
+  endpoints-watcher:
+    watch-restart-delay-seconds: ${WATCH_RESTART_DELAY_SECONDS:30}
   target:
     path: ${ON_UPDATE_PATH:/kafka-keyvalue/v1/updates}
     service:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -50,6 +50,8 @@ quarkus:
         level: DEBUG
       "org.apache.kafka.clients.Metadata":
         level: DEBUG
+      "io.fabric8.kubernetes.client":
+        level: DEBUG
 
   kafka:
     snappy:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,7 @@
 kkv:
   endpoints-watcher:
-    watch-restart-delay-seconds: ${WATCH_RESTART_DELAY_SECONDS:30}
+    watch-restart-delay-min: ${WATCH_RESTART_DELAY_MIN:1ms}
+    watch-restart-delay-max: ${WATCH_RESTART_DELAY_MAX:60s}
   target:
     path: ${ON_UPDATE_PATH:/kafka-keyvalue/v1/updates}
     service:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,6 +52,8 @@ quarkus:
         level: DEBUG
       "io.fabric8.kubernetes.client":
         level: DEBUG
+      "io.vertx.core.http":
+        level: DEBUG
 
   kafka:
     snappy:

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,8 +55,13 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Integer watchRestartDelaySeconds() {
-        return 1;
+      public Duration watchRestartDelayMin() {
+        return Duration.ofSeconds(1);
+      }
+
+      @Override
+      public Duration watchRestartDelayMax() {
+        return Duration.ofSeconds(1);
       }
 
     }, new SimpleMeterRegistry());
@@ -85,8 +91,13 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Integer watchRestartDelaySeconds() {
-        return 1;
+      public Duration watchRestartDelayMin() {
+        return Duration.ofSeconds(1);
+      }
+
+      @Override
+      public Duration watchRestartDelayMax() {
+        return Duration.ofSeconds(1);
       }
 
     }, new SimpleMeterRegistry());
@@ -112,8 +123,13 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Integer watchRestartDelaySeconds() {
-        return 1;
+      public Duration watchRestartDelayMin() {
+        return Duration.ofSeconds(1);
+      }
+
+      @Override
+      public Duration watchRestartDelayMax() {
+        return Duration.ofSeconds(1);
       }
 
     }, new SimpleMeterRegistry());
@@ -158,8 +174,13 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Integer watchRestartDelaySeconds() {
-        return 1;
+      public Duration watchRestartDelayMin() {
+        return Duration.ofSeconds(1);
+      }
+
+      @Override
+      public Duration watchRestartDelayMax() {
+        return Duration.ofSeconds(1);
       }
 
     }, new SimpleMeterRegistry());
@@ -215,6 +236,56 @@ public class EndpointsWatcherTest {
     assertEquals(receivedUpdates, List.of(update, Map.of("192.168.0.3", "pod3")));
     assertEquals(Map.of(), watcher.getUnreadyTargets());
     assertEquals(Map.of("192.168.0.1", "pod1", "192.168.0.3", "pod3"), watcher.getTargets());
+  }
+
+  @Test
+  void testGetRetryDelayMs() {
+    EndpointsWatcher watcher = new EndpointsWatcher(new EndpointsWatcherConfig() {
+
+      @Override
+      public Optional<String> targetServiceName() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Duration watchRestartDelayMin() {
+        return Duration.ofSeconds(1);
+      }
+
+      @Override
+      public Duration watchRestartDelayMax() {
+        return Duration.ofSeconds(10);
+      }
+
+    }, new SimpleMeterRegistry());
+
+    assertEquals(1000, watcher.getRetryDelayMs(0));
+    assertEquals(5.5 * 1000, watcher.getRetryDelayMs(0.5));
+    assertEquals(7.3 * 1000, watcher.getRetryDelayMs(0.7));
+    assertEquals(10 * 1000, watcher.getRetryDelayMs(1));
+
+    watcher = new EndpointsWatcher(new EndpointsWatcherConfig() {
+
+      @Override
+      public Optional<String> targetServiceName() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Duration watchRestartDelayMin() {
+        return Duration.ofMillis(1);
+      }
+
+      @Override
+      public Duration watchRestartDelayMax() {
+        return Duration.ofSeconds(60);
+      }
+
+    }, new SimpleMeterRegistry());
+    assertEquals(1, watcher.getRetryDelayMs(0));
+    assertEquals(30 * 1000, watcher.getRetryDelayMs(0.5));
+    assertEquals(42 * 1000, watcher.getRetryDelayMs(0.7));
+    assertEquals(60 * 1000, watcher.getRetryDelayMs(1));
   }
 
 }

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
@@ -53,6 +53,11 @@ public class EndpointsWatcherTest {
         return Optional.empty();
       }
 
+      @Override
+      public Integer watchRestartDelaySeconds() {
+        return 1;
+      }
+
     }, new SimpleMeterRegistry());
     watcher.client = mock(KubernetesClient.class);
     when(watcher.client.endpoints()).thenReturn(mixedOperationMock);
@@ -79,6 +84,11 @@ public class EndpointsWatcherTest {
         return Optional.of("target-service-name");
       }
 
+      @Override
+      public Integer watchRestartDelaySeconds() {
+        return 1;
+      }
+
     }, new SimpleMeterRegistry());
     watcher.client = mock(KubernetesClient.class);
     when(watcher.client.endpoints()).thenReturn(mixedOperationMock);
@@ -99,6 +109,11 @@ public class EndpointsWatcherTest {
       @Override
       public Optional<String> targetServiceName() {
         return Optional.empty();
+      }
+
+      @Override
+      public Integer watchRestartDelaySeconds() {
+        return 1;
       }
 
     }, new SimpleMeterRegistry());
@@ -140,6 +155,11 @@ public class EndpointsWatcherTest {
       @Override
       public Optional<String> targetServiceName() {
         return Optional.empty();
+      }
+
+      @Override
+      public Integer watchRestartDelaySeconds() {
+        return 1;
       }
 
     }, new SimpleMeterRegistry());

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import se.yolean.kafka.keyvalue.UpdateRecord;
 import se.yolean.kafka.keyvalue.onupdate.UpdatesBodyPerTopicJSON;
 
@@ -52,7 +53,7 @@ public class EndpointsWatcherTest {
         return Optional.empty();
       }
 
-    });
+    }, new SimpleMeterRegistry());
     watcher.client = mock(KubernetesClient.class);
     when(watcher.client.endpoints()).thenReturn(mixedOperationMock);
 
@@ -78,7 +79,7 @@ public class EndpointsWatcherTest {
         return Optional.of("target-service-name");
       }
 
-    });
+    }, new SimpleMeterRegistry());
     watcher.client = mock(KubernetesClient.class);
     when(watcher.client.endpoints()).thenReturn(mixedOperationMock);
 
@@ -100,7 +101,7 @@ public class EndpointsWatcherTest {
         return Optional.empty();
       }
 
-    });
+    }, new SimpleMeterRegistry());
 
     List<EndpointAddress> notReadyAddresses = List.of(
       createEndpoint("192.168.0.1", "pod1"),
@@ -141,7 +142,7 @@ public class EndpointsWatcherTest {
         return Optional.empty();
       }
 
-    });
+    }, new SimpleMeterRegistry());
 
     List<EndpointAddress> notReadyAddresses = List.of(
       createEndpoint("192.168.0.1", "pod1"),

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
@@ -57,8 +57,8 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public String namespace() {
-        return "dev";
+      public Optional<String> targetServiceNamespace() {
+        return Optional.of("dev");
       }
 
       @Override
@@ -96,8 +96,8 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public String namespace() {
-        return "dev";
+      public Optional<String> targetServiceNamespace() {
+        return Optional.of("dev");
       }
 
       @Override
@@ -131,8 +131,8 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public String namespace() {
-        return "dev";
+      public Optional<String> targetServiceNamespace() {
+        return Optional.of("dev");
       }
 
       @Override
@@ -182,8 +182,8 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public String namespace() {
-        return "dev";
+      public Optional<String> targetServiceNamespace() {
+        return Optional.of("dev");
       }
 
       @Override

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/EndpointsWatcherTest.java
@@ -62,7 +62,7 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Duration resyncPeriod() {
+      public Duration informerResyncPeriod() {
         return Duration.ofMinutes(5);
       }
 
@@ -101,7 +101,7 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Duration resyncPeriod() {
+      public Duration informerResyncPeriod() {
         return Duration.ofMinutes(5);
       }
 
@@ -136,7 +136,7 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Duration resyncPeriod() {
+      public Duration informerResyncPeriod() {
         return Duration.ofMinutes(5);
       }
 
@@ -187,7 +187,7 @@ public class EndpointsWatcherTest {
       }
 
       @Override
-      public Duration resyncPeriod() {
+      public Duration informerResyncPeriod() {
         return Duration.ofMinutes(5);
       }
 

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/WatcherReconnectIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/WatcherReconnectIntegrationTest.java
@@ -1,6 +1,6 @@
 package se.yolean.kafka.keyvalue.kubernetes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -52,10 +52,10 @@ public class WatcherReconnectIntegrationTest {
 
   @Test
   void test() {
-    assertEquals(0, (int) registry.counter("kkv.watcher.close").count());
     performAndWaitOrThrow("Waiting for readiness", () -> {
       return RestAssured.get("/q/health/ready").andReturn();
     }, res -> res.statusCode() == 200, 10);
+    assertTrue(RestAssured.get("/q/metrics").andReturn().asString().contains("kkv_watcher_down 0.0"));
 
     logger.info("initial targets: {}", watcher.getTargets());
     performAndWaitOrThrow("Waiting for the pod to be ready so that EndpointsWatcher picks up  the target", () -> {
@@ -118,7 +118,7 @@ public class WatcherReconnectIntegrationTest {
       // Here we find existing pods in the k3s cluster
       return Map.of(
         "kkv.target.service.name", "metrics-server",
-        "kkv.namespace", "kube-system"
+        "kkv.target.service.namespace", "kube-system"
       );
     }
 

--- a/src/test/java/se/yolean/kafka/keyvalue/kubernetes/WatcherReconnectIntegrationTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/kubernetes/WatcherReconnectIntegrationTest.java
@@ -1,0 +1,104 @@
+package se.yolean.kafka.keyvalue.kubernetes;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.k3s.K3sContainer;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.RestAssured;
+import io.smallrye.mutiny.Uni;
+import jakarta.inject.Inject;
+import se.yolean.kafka.keyvalue.testresources.InjectK3sContainer;
+import se.yolean.kafka.keyvalue.testresources.K3sTestResource;
+
+@Tag("devservices")
+@QuarkusTest
+@QuarkusTestResource(value = K3sTestResource.class, restrictToAnnotatedClass = true)
+@TestProfile(WatcherReconnectIntegrationTest.EndpointsWatcherEnabledTestProfile.class)
+public class WatcherReconnectIntegrationTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(WatcherReconnectIntegrationTest.class);
+
+  @Inject
+  MeterRegistry registry;
+
+  @InjectK3sContainer
+  K3sContainer k3s;
+
+  @Inject
+  KubernetesClient client;
+
+  @Test
+  void test() {
+    assertEquals(0, (int) registry.counter("kkv.watcher.close").count());
+    performAndWaitOrThrow("Waiting for readiness", () -> {
+      return RestAssured.get("/q/health/ready").andReturn();
+    }, res -> res.statusCode() == 200);
+
+    performAndWaitOrThrow("Waiting for EndpointsWatcher to pick up endpoints", () -> {
+      return registry.find("kkv.watcher.health.unknown").gauge().value();
+    }, res -> res.equals(0d));
+
+    logger.info("Restarting k3s");
+    k3s.getDockerClient().restartContainerCmd(k3s.getContainerId()).exec();
+
+    performAndWaitOrThrow("Waiting for EndpointsWatcher to lose its watch", () -> {
+      return registry.find("kkv.watcher.health.unknown").gauge().value();
+    }, res -> res.equals(1d));
+
+    performAndWaitOrThrow("Waiting for the api server to respond after the restart", () -> {
+      return client.namespaces().list().toString();
+    }, res -> res != null);
+
+    // A simple way to cause events is to rollout restart some deployment
+    client.apps().deployments().inNamespace("kube-system").withName("metrics-server").rolling().restart();
+    performAndWaitOrThrow("Waiting for EndpointsWatcher to recover and pick up endpoints changes", () -> {
+      return registry.find("kkv.watcher.health.unknown").gauge().value();
+    }, res -> res.equals(0d));
+  }
+
+  /**
+   * This pattern is reused every time we wait for the application to react to some change
+   */
+  private <T> T performAndWaitOrThrow(String name, Supplier<T> action, Predicate<T> waitUntil) {
+    logger.debug(name);
+    return Uni.createFrom().item(() -> {
+      T result = action.get();
+      boolean ok = waitUntil.test(result);
+      if (!ok) {
+        throw new RuntimeException(String.format("Result did not fulfill predicate for action \"%s\"", name));
+      }
+      logger.debug("Action \"{}\" completed successfully", name);
+      return result;
+    }).onFailure()
+      .retry()
+      .withBackOff(Duration.ofSeconds(1), Duration.ofSeconds(1))
+      .atMost(30)
+      .await()
+      .indefinitely();
+  }
+
+  public static class EndpointsWatcherEnabledTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+      return Map.of("kkv.target.service.name", "metrics-server");
+    }
+
+  }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclientTest.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/onupdate/webclient/UpdatesDispatcherWebclientTest.java
@@ -75,8 +75,8 @@ public class UpdatesDispatcherWebclientTest {
     var registry = new SimpleMeterRegistry();
 
     assertEquals("", registry.getMetersAsString());
-    UpdatesDispatcherWebclient.initMetrics(registry);
-    assertEquals("kkv.target.update.failure(COUNTER)[]; count=0.0", registry.getMetersAsString());
+    dispatcher.initMetrics(registry);
+    assertEquals("kkv.target.update.failure(COUNTER)[]; count=0.0\nkkv.target.update.ok(COUNTER)[]; count=0.0", registry.getMetersAsString());
   }
 
 

--- a/src/test/java/se/yolean/kafka/keyvalue/testresources/InjectK3sContainer.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/testresources/InjectK3sContainer.java
@@ -1,0 +1,11 @@
+package se.yolean.kafka.keyvalue.testresources;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectK3sContainer {
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/testresources/K3sTestResource.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/testresources/K3sTestResource.java
@@ -1,0 +1,42 @@
+package se.yolean.kafka.keyvalue.testresources;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.testcontainers.k3s.K3sContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+public class K3sTestResource implements QuarkusTestResourceLifecycleManager {
+
+    K3sContainer k3s;
+    String configYaml;
+
+    @Override
+    public Map<String, String> start() {
+      k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.27.9-k3s1"));
+      k3s.setPortBindings(List.of("6443:6443"));
+      k3s.start();
+
+      configYaml = k3s.getKubeConfigYaml();
+
+      System.setProperty("test.kubeconfig", configYaml);
+      Map<String, String> props = new HashMap<>();
+      props.put("test.kubeconfig", configYaml);
+      return props;
+    }
+
+    @Override
+    public void stop() {
+      k3s.stop();
+    }
+
+    @Override
+    public void inject(TestInjector testInjector) {
+      testInjector.injectIntoFields(this.k3s,
+          new TestInjector.AnnotatedAndMatchesType(InjectK3sContainer.class, K3sContainer.class));
+    }
+
+}

--- a/src/test/java/se/yolean/kafka/keyvalue/testresources/KubernetesClientProducer.java
+++ b/src/test/java/se/yolean/kafka/keyvalue/testresources/KubernetesClientProducer.java
@@ -1,0 +1,41 @@
+package se.yolean.kafka.keyvalue.testresources;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
+import io.quarkus.arc.profile.IfBuildProfile;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class KubernetesClientProducer {
+
+  private KubernetesClient client;
+
+  @Produces
+  @Singleton
+  @IfBuildProfile("test")
+  public KubernetesClient kubernetesClient(KubernetesSerialization serialization) {
+    if (client == null) {
+      String yamlConfig = System.getProperty("test.kubeconfig");
+
+      Config config = Config.fromKubeconfig(yamlConfig);
+      client = new KubernetesClientBuilder()
+          .withKubernetesSerialization(serialization)
+          .withConfig(config)
+          .build();
+    }
+
+    return client;
+  }
+
+  @PreDestroy
+  public void destroy() {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,8 +1,9 @@
 '%test':
   kkv:
-    namespace: dev
-    endpoints-watcher:
-      resync-period: 5m
+    target:
+      service:
+        namespace: dev
+        informer-resync-period: 5m
 
   quarkus:
     kafka:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,9 +1,8 @@
 '%test':
   kkv:
+    namespace: dev
     endpoints-watcher:
-      # Quick retries for unit tests
-      watch-restart-delay-min: 1s
-      watch-restart-delay-max: 1s
+      resync-period: 5m
 
   quarkus:
     kafka:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,6 +1,8 @@
 '%test':
   quarkus:
     kafka:
+      snappy:
+        enabled: false
       devservices:
         topic-partitions:
           mytopic: 3

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -2,7 +2,8 @@
   kkv:
     endpoints-watcher:
       # Quick retries for unit tests
-      watch-restart-delay-seconds: 1
+      watch-restart-delay-min: 1s
+      watch-restart-delay-max: 1s
 
   quarkus:
     kafka:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,4 +1,9 @@
 '%test':
+  kkv:
+    endpoints-watcher:
+      # Quick retries for unit tests
+      watch-restart-delay-seconds: 1
+
   quarkus:
     kafka:
       snappy:


### PR DESCRIPTION
We mistakenly did not implement any behavior for when our watch for kubernetes endpoints closed gracefully, since it [has a default implementation that only logs a message on the debug level.](https://github.com/fabric8io/kubernetes-client/blob/main/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Watcher.java#L44)

- [x] Log on DEBUG-level for the kubernetes client.

- [x] Handle graful watcher close the same way we handle exception close (log and exit the application with code 11).